### PR TITLE
Send code coverage data to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ env:
 
 notifications:
     email: false
+
+after_success:
+  - pip install python-coveralls
+  - cd mhep
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # My Home Energy Planner (MHEP) Django
 
 [![Build Status](https://travis-ci.org/mhep-transition/mhep-django.svg?branch=master)](https://travis-ci.org/mhep-transition/mhep-django)
+[![Coverage Status](https://coveralls.io/repos/github/mhep-transition/mhep-django/badge.svg?branch=master)](https://coveralls.io/github/mhep-transition/mhep-django?branch=master)
 
 ## Install Vagrant & Virtualbox
 

--- a/mhep/pytest.ini
+++ b/mhep/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ds=config.settings.test
+addopts = --ds=config.settings.test --cov=.

--- a/mhep/requirements/local.txt
+++ b/mhep/requirements/local.txt
@@ -10,6 +10,7 @@ psycopg2==2.8.3 --no-binary psycopg2  # https://github.com/psycopg/psycopg2
 mypy==0.720  # https://github.com/python/mypy
 pytest==5.0.1  # https://github.com/pytest-dev/pytest
 freezegun==0.3.12  # https://github.com/spulec/freezegun
+pytest-cov==2.7.1 # https://pypi.org/project/pytest-cov/
 
 # Code quality
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Run `pytest` with `--cov` to generate a coverage report, then use the `coveralls` command line to upload that to [coveralls.io](https://coveralls.io/github/mhep-transition/mhep-django)