### PR TITLE
rename urls

### DIFF
--- a/mhep/mhep/assessments/tests/test_urls.py
+++ b/mhep/mhep/assessments/tests/test_urls.py
@@ -9,17 +9,20 @@ pytestmark = pytest.mark.django_db
 
 def test_list_create_assessments(assessment: Assessment):
     assert (
-        reverse("assessments:list-create") == f"/api/v1/assessments/"
+        reverse("assessments:list-create-assessments") == f"/api/v1/assessments/"
     )
-    assert resolve(f"/api/v1/assessments/").view_name == "assessments:list-create"
+    assert resolve(f"/api/v1/assessments/").view_name == "assessments:list-create-assessments"
 
 
 def test_assessment_detail(assessment: Assessment):
     assert (
-        reverse("assessments:detail", kwargs={"pk": assessment.id})
+        reverse("assessments:assessment-detail", kwargs={"pk": assessment.id})
         == f"/api/v1/assessments/{assessment.id}/"
     )
-    assert resolve(f"/api/v1/assessments/{assessment.id}/").view_name == "assessments:detail"
+    assert (
+        resolve(f"/api/v1/assessments/{assessment.id}/").view_name
+        == "assessments:assessment-detail"
+    )
 
 
 @pytest.fixture

--- a/mhep/mhep/assessments/urls.py
+++ b/mhep/mhep/assessments/urls.py
@@ -8,6 +8,14 @@ from mhep.assessments.views import (
 
 app_name = "assessments"
 urlpatterns = [
-    path("api/v1/assessments/", view=ListCreateAssessments.as_view(), name="list-create"),
-    path("api/v1/assessments/<int:pk>/", view=AssessmentDetail.as_view(), name="detail"),
+    path(
+        "api/v1/assessments/",
+        view=ListCreateAssessments.as_view(),
+        name="list-create-assessments"
+    ),
+    path(
+        "api/v1/assessments/<int:pk>/",
+        view=AssessmentDetail.as_view(),
+        name="assessment-detail"
+    ),
 ]


### PR DESCRIPTION
because we're gonna need `assessments:list-libraries`, we need to rename
to `assessments:assessment-detail` and `assessments:list-assessments`