### PR TITLE
Add list organiosation assessments endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,3 +360,35 @@ Returns:
 ```
 HTTP 204 No content
 ```
+
+# Dummy API endpoints
+
+In this first release, where we have no concept of an organisation, the following endpoints have been hardcoded to return
+certain values.
+
+* [List organisation assessments](#list-organisation-assessments)
+
+## List organisation assessments
+
+```
+GET /organisations/:id/assessments/
+```
+
+List all assessments belonging to the organisation.
+
+ℹ️ porting notes: replaces previous `assessment/list` route, passing `orgid`.
+
+### Example
+
+```
+> curl http://localhost:9090/api/v1/organisations/1/assessments/
+```
+
+Returns:
+
+```
+HTTP 200 OK
+Content-Type: application/json
+
+[]
+```

--- a/mhep/mhep/assessments/tests/test_urls.py
+++ b/mhep/mhep/assessments/tests/test_urls.py
@@ -25,6 +25,17 @@ def test_assessment_detail_update_destroy(assessment: Assessment):
     )
 
 
+def test_list_organisation_assessments():
+    assert (
+        reverse("assessments:list-organisation-assessments", kwargs={"pk": 1})
+        == f"/api/v1/organisations/1/assessments/"
+    )
+    assert (
+        resolve(f"/api/v1/organisations/1/assessments/").view_name
+        == "assessments:list-organisation-assessments"
+    )
+
+
 @pytest.fixture
 def assessment():
     return Assessment.objects.create(

--- a/mhep/mhep/assessments/tests/test_views.py
+++ b/mhep/mhep/assessments/tests/test_views.py
@@ -196,3 +196,11 @@ class TestListCreateAssessments(APITestCase):
         response = self.client.post("/api/v1/assessments/", new_assessment, format="json")
         assert response.status_code == expected_status
         assert response.data == expected_response
+
+
+class TestListOrganisationAssessments(APITestCase):
+    def test_list_organisation_assessments(self):
+        response = self.client.get("/api/v1/organisations/1/assessments/")
+        assert response.status_code == status.HTTP_200_OK
+
+        assert [] == response.data

--- a/mhep/mhep/assessments/urls.py
+++ b/mhep/mhep/assessments/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from mhep.assessments.views import (
     RetrieveUpdateDestroyAssessment,
     ListCreateAssessments,
+    ListOrganisationAssessments,
 )
 
 app_name = "assessments"
@@ -17,5 +18,11 @@ urlpatterns = [
         "api/v1/assessments/<int:pk>/",
         view=RetrieveUpdateDestroyAssessment.as_view(),
         name="retrieve-update-destroy-assessment",
+    ),
+
+    path(
+        "api/v1/organisations/<int:pk>/assessments/",
+        view=ListOrganisationAssessments.as_view(),
+        name="list-organisation-assessments"
     ),
 ]

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -1,4 +1,5 @@
 from rest_framework import generics
+from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 
@@ -29,3 +30,8 @@ class RetrieveUpdateDestroyAssessment(
             return Response(None, status.HTTP_204_NO_CONTENT)
         else:
             return response
+
+
+class ListOrganisationAssessments(APIView):
+    def get(self, request, *args, **kwargs):
+        return Response([], status.HTTP_200_OK)


### PR DESCRIPTION
This is hard coded to return an empty array since we don't have a concept of an organisation at this stage.

```
GET /organisations/:id/assessments/
```

List all assessments belonging to the organisation.

ℹ️ porting notes: replaces previous `assessment/list` route, passing `orgid`.

⚠️ In this first release, where we have no concept of an organisation, this endpoint is hardcoded to return an empty array


```
> curl http://localhost:9090/api/v1/organisations/1/assessments/
```

Returns:

```
HTTP 200 OK
Content-Type: application/json

[]
```