### PR TITLE
library admin: don't call json.loads()

### DIFF
--- a/mhep/mhep/assessments/admin.py
+++ b/mhep/mhep/assessments/admin.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib import admin
 
 from mhep.assessments.models import Assessment, Library
@@ -17,4 +15,4 @@ class LibraryAdmin(admin.ModelAdmin):
     search_fields = ["name", "type"]
 
     def number_of_items(self, obj):
-        return len(json.loads(obj.data))
+        return len(obj.data)


### PR DESCRIPTION
django does this for us, JSONField returns native Python objects