### PR TITLE
Point Emoncms at Django API endpoints

### DIFF
--- a/mhep-emoncms/assessment_controller.php
+++ b/mhep-emoncms/assessment_controller.php
@@ -83,6 +83,7 @@ function assessment_controller() {
     }
 
     if ($route->format == 'json') {
+        return false; // disable all JSON endpoints
 
         require_once "Modules/assessment/organisation_model.php";
         $organisation = new Organisation($mysqli);

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -3357,12 +3357,9 @@ libraryHelper.prototype.load_user_libraries = function (callback) {
         async: false,
         datatype: "json",
         success: function (result) {
-            //result = JSON.parse(result);
             for (library in result) {
                 if (mylibraries[result[library].type] === undefined)
                     mylibraries[result[library].type] = [];
-                result[library].data = result[library].data.replace('\\/plus', '+'); // For a reason i have not been able to find why the character + becomes a carrier return when it is accesed in $_POST in the controller, because of this we escape + with \plus
-                result[library].data = JSON.parse(result[library].data);
                 mylibraries[result[library].type].push(result[library]);
             }
             if (callback !== undefined)

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -481,17 +481,22 @@ libraryHelper.prototype.onCreateInLibraryOk = function (library_id) {
         else if (selected_library.data[tag] != undefined)
             $("#create-in-library-message").html("Tag already exist, choose another one");
         else {
-            //selected_library.data[tag] = item[tag];
-            var item_string = JSON.stringify(item[tag]);
-            item_string = item_string.replace(/&/g, 'and');
-            $.ajax({type: "POST", url: path + "assessment/additemtolibrary.json", data: "library_id=" + selected_library.id + "&tag=" + tag + "&item=" + item_string, success: function (result) {
-                    if (result == true) {
-                        $("#create-in-library-message").html("Item added to the library");
-                        $('#modal-create-in-library button').hide('fast');
-                        $('#create-in-library-finish').show('fast');
-                    }
-                    else
-                        $("#create-in-library-message").html("There were problems saving the library");
+            $.ajax({
+                type: "POST",
+                url: apiURL + '/libraries/' + selected_library.id + '/items/',
+                data: JSON.stringify({
+                    'tag': tag,
+                    'item': item[tag],
+                }),
+                dataType: "json",
+                contentType: "application/json;charset=utf-8",
+                success: function (result) {
+                    $("#create-in-library-message").html("Item added to the library");
+                    $('#modal-create-in-library button').hide('fast');
+                    $('#create-in-library-finish').show('fast');
+                },
+                error: function (result) {
+                    $("#create-in-library-message").html("There were problems saving the library");
                 }});
         }
     }

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -393,21 +393,6 @@ libraryHelper.prototype.onChangeEmptyOrCopyLibrary = function () {
 libraryHelper.prototype.onCreateNewLibrary = function () {
     $("#create-library-message").html('');
     var myself = this;
-    var callback = function (resultado) {
-        if (resultado == '0' || resultado == 0)
-            $("#create-library-message").html('Library could not be created');
-        if (typeof resultado == 'number') {
-            myself.load_user_libraries();
-            myself.get_library_permissions();
-            $("#create-library-message").html('Library created');
-            $('#cancelnewlibrary').hide('fast');
-            $('#newlibrary').hide('fast');
-            $('#finishcreatelibrary').show('fast');
-            UpdateUI(data);
-        }
-        else
-            $("#create-library-message").html(resultado)
-    };
     var name = $("#new-library-name").val();
     if (name === '')
         $("#create-library-message").html('User name cannot be empty');
@@ -420,9 +405,29 @@ libraryHelper.prototype.onCreateNewLibrary = function () {
                 }});
         }
         else {
-            $.ajax({url: path + "assessment/newlibrary.json", data: "name=" + name + "&type=" + this.type, datatype: "json", success: function (result) {
-                    callback(result);
-                }});
+            const body = JSON.stringify({
+                'name': name,
+                'type': this.type,
+            });
+            // create new library
+            $.ajax({
+                url: apiURL + '/libraries/',
+                type: 'POST',
+                data: body,
+                datatype: "json",
+                contentType: "application/json;charset=utf-8",
+                success: function (result) {
+                    myself.load_user_libraries();
+                    $("#create-library-message").html('Library created');
+                    $('#cancelnewlibrary').hide('fast');
+                    $('#newlibrary').hide('fast');
+                    $('#finishcreatelibrary').show('fast');
+                    UpdateUI(data);
+                },
+                error: function (result) {
+                    $("#create-library-message").html('Library could not be created');
+                }
+            });
         }
     }
 };

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -834,15 +834,19 @@ libraryHelper.prototype.onDeleteLibrary = function (library_id) {
 }
 libraryHelper.prototype.onDeleteLibraryOk = function (library_id) {
     var myself = this;
-    $.ajax({url: path + "assessment/deletelibrary.json", data: "library_id=" + library_id, async: false, datatype: "json", success: function (result) {
-            if (result == 1) {
-                $('#confirm-delete-library-modal').modal('hide');
-                myself.init();
-                UpdateUI();
-            }
-            else
-                $('#confirm-delete-library-modal .message').html('Library could not be deleted - ' + result);
-        }});
+    $.ajax({
+        url: apiURL + "/libraries/" + library_id,
+        type: 'DELETE',
+        async: false,
+        success: function () {
+            $('#confirm-delete-library-modal').modal('hide');
+            myself.init();
+            UpdateUI();
+        },
+        error : function (response) {
+            $('#confirm-delete-library-modal .message').html('Library could not be deleted - ' + response.responseJSON.detail);
+        },
+    });
 }
 libraryHelper.prototype.onShowLibraryItemsEditMode = function (library_id) {
     var library = this.get_library_by_id(library_id);

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -24,7 +24,6 @@ function libraryHelper(type, container) {
 
 libraryHelper.prototype.init = function () {
     this.load_user_libraries(); // Populates this.library_list
-    this.get_library_permissions(); // Populates this.library_permissions
     this.library_names = {
         'elements': 'Fabric elements',
         'systems': 'Energy systems',
@@ -363,7 +362,8 @@ libraryHelper.prototype.onSelectingLibraryToShow = function (origin) {
         $("#library_table").html(out);
         $('#create-in-library').attr('library-id', id);
         // Hide/show "share" option according to the permissions
-        if (this.library_permissions[id].write == 0)
+        const library = this.get_library_by_id(id);
+        if (!library.writeable)
             $('.if-write').hide('fast');
         else
             $('.if-write').show('fast');
@@ -788,7 +788,7 @@ libraryHelper.prototype.onShowLibraryItems = function (library_id) {
     // Hide the Use buttons
     $("#show-library-items-modal .use-from-lib").hide('fast');
     // Hide Write options if no write access
-    if (this.library_permissions[library.id].write != 1)
+    if (!library.writeable)
         $("#show-library-items-modal .if-write").hide('fast');
     // Show the select to choose the type of fabric elements when library is "elements"
     if (this.type == 'elements' || this.type == 'elements_measures')
@@ -812,7 +812,8 @@ libraryHelper.prototype.onChangeTypeOfElementsToShow = function (origin) {
     // Hide the Use buttons
     $("#show-library-items-modal .use-from-lib").hide('fast');
     // Hide Write options if no write access
-    if (this.library_permissions[library_id].write != 1)
+    const library = this.get_library_by_id(library_id)
+    if (!library.writeable)
         $("#show-library-items-modal .if-write").hide('fast');
     // Show the select to choose the type of fabric elements when library is "elements"
     $('#show-library-items-modal .element-type').show('fast');
@@ -848,7 +849,7 @@ libraryHelper.prototype.onShowLibraryItemsEditMode = function (library_id) {
     var out = this[function_name](null, library_id);
     $("#show-library-modal-edit-mode .modal-body").html(out);
     // Hide Write options if no write access
-    if (this.library_permissions[library.id].write != 1)
+    if (!library.writeable)
         $("#show-library-modal-edit-mode .if-write").hide('fast');
     // Add library id to "Create new item" and "Save" buttons
     $('#show-library-modal-edit-mode #create-in-library').attr('library-id', library_id);
@@ -3367,16 +3368,6 @@ libraryHelper.prototype.load_user_libraries = function (callback) {
             myself.library_list = mylibraries;
         }});
 };
-libraryHelper.prototype.get_library_permissions = function (callback) {
-    var mypermissions = {};
-    var myself = this;
-    $.ajax({url: path + "assessment/getuserpermissions.json", async: false, datatype: "json", success: function (result) {
-            if (callback !== undefined)
-                callback();
-            myself.library_permissions = result;
-        }});
-    //return mypermissions;
-};
 libraryHelper.prototype.display_library_users = function (library_id) {
     $.ajax({url: path + "assessment/getsharedlibrary.json", data: "id=" + library_id, success: function (shared) {
             var out = "<tr><th>Shared with:</th><th>Has write persmissions</th><th></th></tr>";
@@ -3435,7 +3426,7 @@ libraryHelper.prototype.populate_library_modal = function (origin) {
     // Add library id to "Add item from library" button
     $('#create-in-library').attr('library-id', id);
     // Hide/show "share" option according to the permissions
-    if (this.library_permissions[id].write == 0)
+    if (!this.get_library_by_id(id).writeable)
         $('.if-write').hide('fast');
     else
         $('.if-write').show('fast');

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -331,17 +331,7 @@ libraryHelper.prototype.onEditLibraryNameOk = function () {
     var library_id = $('#edit-library-name-modal #edit-library-name-ok').attr('library-id');
     var library_new_name = $('#edit-library-name-modal #new-library-name').val();
     var myself = this;
-    this.set_library_name(library_id, library_new_name, function (result) {
-        console.log(myself);
-        if (result == 1) {
-            var library = myself.get_library_by_id(library_id);
-            library.name = library_new_name;
-            UpdateUI(data);
-            $('.modal').modal('hide');
-        }
-        else
-            $('#edit-library-name-modal #message').html('Library name could not be changed: ' + result);
-    });
+    this.set_library_name(library_id, library_new_name);
     //this.set_library_name(library_id, library_new_name);
 };
 libraryHelper.prototype.onRemoveUserFromSharedLib = function (user_to_remove, selected_library) {
@@ -3414,9 +3404,29 @@ libraryHelper.prototype.populate_measure_new_item = function (type_of_library) {
     $('#apply-measure-item-fields').html(out);
 };
 libraryHelper.prototype.set_library_name = function (library_id, new_name, callback) {
-    $.ajax({url: path + "assessment/setlibraryname.json", data: "library_id=" + library_id + "&new_library_name=" + new_name, async: false, datatype: "json", success: function (result) {
-            callback(result);
-        }});
+    const body = JSON.stringify({
+        'name': new_name,
+    });
+
+    $.ajax({
+        url: apiURL + "/libraries/" + library_id + "/",
+        type: 'PATCH',
+        data: body,
+        async: false,
+        datatype: "json",
+        contentType: "application/json;charset=utf-8",
+        success: function (response) {
+            var library = library_helper.get_library_by_id(library_id);
+            library.name = new_name;
+            UpdateUI(data);
+            $('.modal').modal('hide');
+        },
+        error: function (response) {
+            $('#edit-library-name-modal #message').html('Library name could not be changed: ' + response.responseJSON.detail);
+        }
+
+
+    });
 };
 libraryHelper.prototype.populate_library_modal = function (origin) {
     // Populate the select to choose library to display

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -3340,7 +3340,11 @@ libraryHelper.prototype.generation_measures_get_item_to_save = function () {
 libraryHelper.prototype.load_user_libraries = function (callback) {
     var mylibraries = {};
     var myself = this;
-    $.ajax({url: path + "assessment/loaduserlibraries.json", async: false, datatype: "json", success: function (result) {
+    $.ajax({
+        url: apiURL + '/libraries/',
+        async: false,
+        datatype: "json",
+        success: function (result) {
             //result = JSON.parse(result);
             for (library in result) {
                 if (mylibraries[result[library].type] === undefined)

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -200,7 +200,9 @@ libraryHelper.prototype.add_events = function () {
         $('#confirm-delete-library-item-modal').modal('show');
     });
     this.container.on('click', '#confirm-delete-library-item-modal #delete-library-item-ok', function () {
-        myself.delete_library_item($(this).attr('library-id'), $(this).attr('tag'));
+        const library_id = $(this).attr('library-id');
+        const tag = $(this).attr('tag');
+        myself.delete_library_item(library_id, tag);
         myself.show_temporally_hidden_modals();
     });
     this.container.on('change', '.item-ventilation_type', function () {
@@ -3447,16 +3449,18 @@ libraryHelper.prototype.populate_selects_in_apply_measure_modal = function (type
 };
 libraryHelper.prototype.delete_library_item = function (library_id, tag) {
     var myself = this;
-    $.ajax({url: path + "assessment/deletelibraryitem.json", data: "library_id=" + library_id + "&tag=" + tag, async: false, datatype: "json", success: function (result) {
-            if (result != true)
-                $('#confirm-delete-library-item-modal .message').html("Item could not be deleted - " + result);
-            else {
+        $.ajax({
+            type: "DELETE",
+            async: false,
+            url: apiURL + "/libraries/"  + library_id + "/items/" + tag + "/",
+            success: function() {
                 $('#confirm-delete-library-item-modal').modal('hide');
-                $('#show-library-items-modal [tag="' + tag + '"]').parent().parent().remove();
-                $('#show-library-modal-edit-mode tr[tag="' + tag + '"]').remove();
                 myself.load_user_libraries();
+            },
+            error: function() {
+                $('#confirm-delete-library-item-modal .message').html("Item could not be deleted - " + result);
             }
-        }});
+        });
 }
 
 libraryHelper.prototype.get_list_of_libraries_for_select = function (library_type) {

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -582,15 +582,20 @@ libraryHelper.prototype.onEditLibraryItemOk = function (library_id) {
         var item_string = JSON.stringify(item[tag]).replace('+', '/plus'); // For a reason i have not been able to find why the character + becomes a carrier return when it is accesed in $_POST in the controller, because of this we escape + with \plus
         item_string = item_string.replace(/&/g, 'and');
         //item[tag].number_of_intermittentfans="\\+2";
-        $.ajax({type: "POST", url: path + "assessment/edititeminlibrary.json", data: "library_id=" + selected_library.id + "&tag=" + tag + "&item=" + item_string, success: function (result) {
-                if (result == true) {
+        $.ajax({type: "PUT",
+            url: apiURL + "/libraries/"  + selected_library.id + "/items/" + tag + "/",
+            data: item_string,
+            contentType: "application/json;charset=utf-8",
+            complete: function(xhr) {
+                if (xhr.status == 204) {
                     $("#edit-item-message").html("Item edited and library saved");
                     $('#modal-edit-item button').hide('fast');
                     $('#edit-item-finish').show('fast');
-                }
-                else
+                } else {
                     $("#edit-item-message").html("There were problems saving the library - " + result);
-            }});
+                }
+            }
+        });
     }
 };
 

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -932,14 +932,21 @@ libraryHelper.prototype.onSaveLibraryEditMode = function (selector, library_id) 
         });
     });
 
-    $.ajax({url: path + "assessment/savelibrary.json", method: 'post', data: 'data=' + JSON.stringify(data) + '&id=' + library_id, async: false, datatype: "json", success: function (result) {
-            if (result != true)
-                alert("Library could not be saved. The server said: " + result);
-            else {
-                $('#show-library-modal-edit-mode #save').attr('disabled', 'disabled');
-                $('#show-library-modal-edit-mode #message').html('Saved');
-            }
-        }});
+    $.ajax({
+        type: 'PATCH',
+        url: apiURL + '/libraries/' + library_id + '/',
+        async: false,
+        data: JSON.stringify({'data': data}),
+        datatype: "json",
+        contentType: "application/json;charset=utf-8",
+        success: function (result) {
+            $('#show-library-modal-edit-mode #save').attr('disabled', 'disabled');
+            $('#show-library-modal-edit-mode #message').html('Saved');
+        },
+        error: function (result) {
+            alert("Library could not be saved. The server said: " + result);
+        }
+    });
 
 }
 

--- a/mhep-emoncms/js/library-helper/library-helper-r1.js
+++ b/mhep-emoncms/js/library-helper/library-helper-r1.js
@@ -386,42 +386,38 @@ libraryHelper.prototype.onCreateNewLibrary = function () {
     $("#create-library-message").html('');
     var myself = this;
     var name = $("#new-library-name").val();
-    if (name === '')
+    if (name === '') {
         $("#create-library-message").html('User name cannot be empty');
-    else {
-        console.log("newlibrary:" + name);
-        if ($("input[name=empty_or_copy_library]:checked").val() == 'copy') {
-            var id = $('#library-to-copy-select').val();
-            $.ajax({url: path + "assessment/copylibrary.json", data: "name=" + name + "&id=" + id + "&type=" + this.type, datatype: "json", success: function (result) {
-                    callback(result);
-                }});
-        }
-        else {
-            const body = JSON.stringify({
-                'name': name,
-                'type': this.type,
-            });
-            // create new library
-            $.ajax({
-                url: apiURL + '/libraries/',
-                type: 'POST',
-                data: body,
-                datatype: "json",
-                contentType: "application/json;charset=utf-8",
-                success: function (result) {
-                    myself.load_user_libraries();
-                    $("#create-library-message").html('Library created');
-                    $('#cancelnewlibrary').hide('fast');
-                    $('#newlibrary').hide('fast');
-                    $('#finishcreatelibrary').show('fast');
-                    UpdateUI(data);
-                },
-                error: function (result) {
-                    $("#create-library-message").html('Library could not be created');
-                }
-            });
-        }
+        return;
     }
+    const new_library_body = {
+        'name': name,
+        'type': this.type,
+    };
+    if ($("input[name=empty_or_copy_library]:checked").val() == 'copy') {
+        const id = $('#library-to-copy-select').val();
+        const library = myself.get_library_by_id(id);
+        new_library_body['data'] = library['data'];
+    }
+    $.ajax({
+        url: apiURL + '/libraries/',
+        type: 'POST',
+        data: JSON.stringify(new_library_body),
+        datatype: "json",
+        contentType: "application/json;charset=utf-8",
+        success: function (result) {
+            myself.load_user_libraries();
+            $("#create-library-message").html('Library created');
+            $('#cancelnewlibrary').hide('fast');
+            $('#newlibrary').hide('fast');
+            $('#finishcreatelibrary').show('fast');
+            UpdateUI(data);
+        },
+        error: function (result) {
+            $("#create-library-message").html('Library could not be created');
+        }
+    });
+
 };
 libraryHelper.prototype.onCreateInLibrary = function (library_id) {
     $('#modal-create-in-library .modal-header h3').html('Create ' + page);

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -33,9 +33,17 @@ var mhep_helper = {
             inputdata[z] = mhep_helper.extract_inputdata(project[z]);
         }
         var result = {};
-        $.ajax({type: 'POST', url: path + "assessment/setdata.json", data: "id=" + parseInt(id) + "&data=" + JSON.stringify(inputdata), async: true, success: function (data) {
-                callback(data)
-            }});
+        $.ajax({
+          type: 'PATCH',
+          url: apiURL + "/assessments/" + parseInt(id) + "/",
+          data: JSON.stringify({'data': inputdata}),
+          dataType: "json",
+          contentType: "application/json;charset=utf-8",
+          async: true,
+          success: function (data) {
+              callback(data)
+          }
+        });
         //console.log(JSON.stringify(inputdata));
     },
     'create': function (name, description, orgid, callback)

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -1,3 +1,5 @@
+const apiURL = "http://localhost:9090/api/v1"
+
 var mhep_helper = {
     apikey: "",
     'getlist': function ()
@@ -18,7 +20,7 @@ var mhep_helper = {
     'get': function (id)
     {
         var result = {};
-        $.ajax({url: path + "assessment/get.json?id=" + parseInt(id), async: false, success: function (data) {
+        $.ajax({url: apiURL + "/assessments/" + parseInt(id) + "/", async: false, success: function (data) {
                 result = data;
             }});
         return result;

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -75,19 +75,25 @@ var mhep_helper = {
     },
     'set_status': function (id, status)
     {
-        var result = 0;
-        $.ajax({type: 'GET', url: path + "assessment/setstatus.json", data: "id=" + id + "&status=" + status, async: false, success: function (data) {
-                result = data;
+        $.ajax({type: 'PATCH',
+            url: apiURL + "/assessments/" + parseInt(id) + "/",
+            data: JSON.stringify({'status': status}),
+            dataType: "json",
+            contentType: "application/json;charset=utf-8",
+            async: false,
+            success: function (data) {
             }});
-        return result;
     },
     'set_name_and_description': function (id, name, description)
     {
-        var result = 0;
-        $.ajax({type: 'POST', url: path + "assessment/setnameanddescription.json", data: "id=" + id + "&name=" + name + "&description=" + description, async: false, success: function (data) {
-                result = data;
+        $.ajax({type: 'PATCH',
+            url: apiURL + "/assessments/" + parseInt(id) + "/",
+            data: JSON.stringify({'name': name, 'description': description}),
+            dataType: "json",
+            contentType: "application/json;charset=utf-8",
+            async: false,
+            success: function (data) {
             }});
-        return result;
     },
     'upload_images': function (id, form_data, callback)
     {
@@ -107,9 +113,15 @@ var mhep_helper = {
     },
     'set_openBEM_version': function (id, version, callback)
     {
-        $.ajax({type: 'POST', url: path + "assessment/setopenBEMversion.json", data: "id=" + id + "&openBEM_version=" + version, success: function (data) {
-                if (data == false)
+        $.ajax({type: 'PATCH',
+            url: apiURL + "/assessments/" + parseInt(id) + "/",
+            data: JSON.stringify({'openbem_version': version}),
+            dataType: "json",
+            contentType: "application/json;charset=utf-8",
+            success: function (data) {
+                if (data == false) {
                     window.alert("There was an error updating openBEM version");
+                }
                 callback(data);
             }});
     },

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -3,14 +3,16 @@ var mhep_helper = {
     'getlist': function ()
     {
         var result = [];
-        var apikeystr = "";
-        if (this.apikey != "")
-            apikeystr = "?apikey=" + this.apikey;
-        $.ajax({url: path + "assessment/list.json" + apikeystr, dataType: 'json', async: false, success: function (data) {
+        $.ajax({
+            url: apiURL + "/assessments/",
+            dataType: 'json',
+            async: false,
+            success: function (data) {
                 result = data;
             }});
-        if (result == "")
+        if (result == "") {
             result = [];
+        }
         return result;
     },
     'get': function (id)

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -50,16 +50,38 @@ var mhep_helper = {
     {
         var result = 0;
         var openBEM_version = {}
-        $.ajax({type: 'GET', async: false, url: "https://api.github.com/repos/carboncoop/openBEM/releases/latest", success: function (data) {
+        $.ajax({
+            type: 'GET',
+            async: false,
+            url: "https://api.github.com/repos/carboncoop/openBEM/releases/latest",
+            success: function (data) {
                 openBEM_version = data.tag_name;
-                var query = "name=" + name + "&description=" + description + "&openBEM_version=" + openBEM_version;
-                if (orgid != undefined)
-                    query += "&org=" + orgid;
-                $.ajax({type: 'GET', url: path + "assessment/create.json", data: query, async: false, success: function (data) {
-                        if (data == false)
+                const newAssessment = {
+                    "name": name,
+                    "description": description,
+                    "openbem_version": openBEM_version,
+                };
+
+                var endpoint;
+                if (orgid != null) {
+                    endpoint = apiURL + '/organisations/' + orgid + '/assessments/';
+                } else {
+                    endpoint = apiURL + '/assessments/';
+                }
+
+                $.ajax({
+                    type: 'POST',
+                    url: endpoint,
+                    data: JSON.stringify(newAssessment),
+                    dataType: 'json',
+                    contentType: "application/json;charset=utf-8",
+                    async: false,
+                    success: function (data) {
+                        if (data == false) {
                             window.alert("Assesment couldn't be created")
-                        else
+                        } else {
                             callback(data);
+                        }
                     }});
             }
         });

--- a/mhep-emoncms/js/mhep-helper.js
+++ b/mhep-emoncms/js/mhep-helper.js
@@ -87,12 +87,19 @@ var mhep_helper = {
         });
         return result;
     },
-    'delete': function (id)
-    {
+    'delete': function (id) {
         var result = 0;
-        $.ajax({type: 'GET', url: path + "assessment/delete.json", data: "id=" + id, async: false, success: function (data) {
-                result = data;
-            }});
+        $.ajax({
+            type: 'DELETE',
+            url: apiURL + "/assessments/" + id + "/",
+            async: false,
+            success: function () {
+                result = 1;
+            },
+            error: function () {
+                result = 0;
+            }
+        });
         return result;
     },
     'set_status': function (id, status)

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -185,9 +185,10 @@ $d = $path . "Modules/assessment/";
 // Check that the user at least one library of each type and if not create it from the default one
 // Check that all the elements in the default library are in the user's Standard library, copy over the ones that are not (kind of getting in sync)
 // -----------------------------------------------------------------------------------
+
     var libraries = {};
     $.ajax({
-      url: path + "assessment/loaduserlibraries.json",
+      url: apiURL + '/libraries/',
       async: true,
       datatype: "json",
       success: function (user_libraries) {

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -199,25 +199,24 @@ $d = $path . "Modules/assessment/";
                     if (user_libraries[library_index].type == library_type)
                         user_has_the_library = true;
                 }
-                if (user_has_the_library == false) {
-                    var library_name = "StandardLibrary - " + myusername;
+                if (!user_has_the_library) {
+                    const library_name = "StandardLibrary - " + myusername;
+
+                    const body = JSON.stringify({
+                      'name': library_name,
+                      'type': library_type,
+                      'data': standard_library[library_type],
+                    });
+
+                    // create new library
                     $.ajax({
-                      url: path + "assessment/newlibrary.json",
-                      data: "name=" + library_name + '&type=' + library_type,
+                      url: apiURL + '/libraries/',
+                      type: 'POST',
+                      data: body,
                       datatype: "json",
+                      contentType: "application/json;charset=utf-8",
                       async: false,
-                      success: function (result) {
-                            var library_id = result;
-                            var library_string = JSON.stringify(standard_library[library_type]);
-                            library_string = library_string.replace(/&/g, 'and');
-                            $.ajax({
-                              type: "POST",
-                              url: path + "assessment/savelibrary.json",
-                              data: "id=" + library_id + "&data=" + library_string,
-                              success: function (result) {
-                                    console.log("Library: " + library_type + ' - ' + result);
-                                }});
-                        }});
+                     });
                 }
             }
             // Check that all the elements in the default library are in the user's Standard library, copy over the ones that are not (kind of getting in sync)

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -468,11 +468,12 @@ $d = $path . "Modules/assessment/";
         }
     });
     $("body").on("click", ".org-item", function () {
+        const apiURL = "http://localhost:9090/api/v1"
         orgid = $(this).attr("orgid");
         draw_organisation(orgid);
         $("#organisation").show();
         viewmode = "organisation";
-        $.ajax({url: path + "assessment/list.json", data: "orgid=" + orgid, success: function (result) {
+        $.ajax({url: apiURL + "/organisations/" + orgid + "/assessments/", success: function (result) {
                 projects = result;
                 draw_projects("#projects", projects);
                 $("#assessments-title").html(myorganisations[orgid].name + " Assessments");

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -186,7 +186,11 @@ $d = $path . "Modules/assessment/";
 // Check that all the elements in the default library are in the user's Standard library, copy over the ones that are not (kind of getting in sync)
 // -----------------------------------------------------------------------------------
     var libraries = {};
-    $.ajax({url: path + "assessment/loaduserlibraries.json", async: true, datatype: "json", success: function (user_libraries) {
+    $.ajax({
+      url: path + "assessment/loaduserlibraries.json",
+      async: true,
+      datatype: "json",
+      success: function (user_libraries) {
             // Check that the user at least one library of each type and if not create it from the default one
             var user_has_the_library = false;
             for (library_type in standard_library) {
@@ -197,11 +201,20 @@ $d = $path . "Modules/assessment/";
                 }
                 if (user_has_the_library == false) {
                     var library_name = "StandardLibrary - " + myusername;
-                    $.ajax({url: path + "assessment/newlibrary.json", data: "name=" + library_name + '&type=' + library_type, datatype: "json", async: false, success: function (result) {
+                    $.ajax({
+                      url: path + "assessment/newlibrary.json",
+                      data: "name=" + library_name + '&type=' + library_type,
+                      datatype: "json",
+                      async: false,
+                      success: function (result) {
                             var library_id = result;
                             var library_string = JSON.stringify(standard_library[library_type]);
                             library_string = library_string.replace(/&/g, 'and');
-                            $.ajax({type: "POST", url: path + "assessment/savelibrary.json", data: "id=" + library_id + "&data=" + library_string, success: function (result) {
+                            $.ajax({
+                              type: "POST",
+                              url: path + "assessment/savelibrary.json",
+                              data: "id=" + library_id + "&data=" + library_string,
+                              success: function (result) {
                                     console.log("Library: " + library_type + ' - ' + result);
                                 }});
                         }});
@@ -224,9 +237,13 @@ $d = $path . "Modules/assessment/";
                     if (library_changed === true) {
                         var library_string = JSON.stringify(user_library);
                         library_string = library_string.replace(/&/g, 'and');
-                        $.ajax({type: "POST", url: path + "assessment/savelibrary.json", data: "id=" + user_libraries[library_index].id + "&data=" + library_string, success: function (result) {
+                        $.ajax({
+                          type: "POST",
+                          url: path + "assessment/savelibrary.json",
+                          data: "id=" + user_libraries[library_index].id + "&data=" + library_string,
+                          success: function (result) {
                                 console.log("Library: " + library_type + ' - ' + result);
-                            }});
+                          }});
                     }
                 }
             }

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -11,12 +11,12 @@ $d = $path . "Modules/assessment/";
     :root {
         --app-color: <?php echo $app_color;?>;
     }
-    
+
     .cc {
         color: var(--app-color);
         font-weight: bold;
         padding-right:20px;
-        
+
     }
 
     .title {
@@ -24,7 +24,7 @@ $d = $path . "Modules/assessment/";
         color:#888;
         float:left;
     }
-    
+
     .recent-activity-item {
         padding:5px;
         border-bottom: 1px solid #ccc;
@@ -272,7 +272,7 @@ $d = $path . "Modules/assessment/";
                 };
             if (viewmode == "organisation" && orgid != 0)
                 mhep_helper.create(name, description, orgid, callback);
-            else 
+            else
                 mhep_helper.create(name, description, null, callback);
             /*var orgselector = "";
             if (viewmode == "organisation" && orgid != 0)
@@ -525,8 +525,8 @@ $d = $path . "Modules/assessment/";
         $("#assessments-title").html("My Assessments");
         $("#myview").show();
     });
-    
-    
+
+
 // -------------------------------------------------------
 // Other
 // -------------------------------------------------------

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -238,9 +238,11 @@ $d = $path . "Modules/assessment/";
                         var library_string = JSON.stringify(user_library);
                         library_string = library_string.replace(/&/g, 'and');
                         $.ajax({
-                          type: "POST",
-                          url: path + "assessment/savelibrary.json",
-                          data: "id=" + user_libraries[library_index].id + "&data=" + library_string,
+                          type: 'PATCH',
+                          url: apiURL + '/libraries/' + user_libraries[library_index].id + '/',
+                          data: JSON.stringify({'data': library_string}),
+                          datatype: "json",
+                          contentType: "application/json;charset=utf-8",
                           success: function (result) {
                                 console.log("Library: " + library_type + ' - ' + result);
                           }});

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -177,12 +177,10 @@ $d = $path . "Modules/assessment/";
 // 1) Load project lists
 // -----------------------------------------------------------------------------------
 
-    var projects = [];
-    $.ajax({url: path + "assessment/list.json", success: function (result) {
-            projects = result;
-            draw_projects("#projects", projects);
-            $("#assessments-title").html("My Assessments");
-        }});
+    var projects = mhep_helper.getlist();
+    draw_projects("#projects", projects);
+
+    $("#assessments-title").html("My Assessments");
 // -----------------------------------------------------------------------------------
 // Check that the user at least one library of each type and if not create it from the default one
 // Check that all the elements in the default library are in the user's Standard library, copy over the ones that are not (kind of getting in sync)
@@ -489,12 +487,11 @@ $d = $path . "Modules/assessment/";
         var viewmode = "personal";
         var orgid = 0;
         $("#organisation").hide();
-        $.ajax({url: path + "assessment/list.json", success: function (result) {
-                projects = result;
-                draw_projects("#projects", projects);
-                $("#assessments-title").html("My Assessments");
-                $("#myview").show();
-            }});
+
+        projects = mhep_helper.getlist();
+        draw_projects("#projects", projects);
+        $("#assessments-title").html("My Assessments");
+        $("#myview").show();
     });
     
     

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -221,20 +221,22 @@ $d = $path . "Modules/assessment/";
                 }
             }
             // Check that all the elements in the default library are in the user's Standard library, copy over the ones that are not (kind of getting in sync)
-            for (library_type in standard_library) {
-                for (library_index in user_libraries) {
-                    var library_changed = false;
-                    if (user_libraries[library_index].type == library_type && user_libraries[library_index].name == "StandardLibrary - " + myusername) {
-                        var user_library = JSON.parse(user_libraries[library_index].data);
+            for (library_type in standard_library) { // e.g. 'appliances_and_cooking'
+                for (let i=0; i < user_libraries.length; i++) {
+                    const user_library = user_libraries[i];
+                    let library_changed = false;
+                    if (user_library.type == library_type && user_library.name == "StandardLibrary - " + myusername) {
+                        var user_library_data = user_library.data;
                         for (item in standard_library[library_type]) {
-                            item = item.replace(/[^\w\s-+.",:{}\/'\[\]\\]/g, ''); // we apply the same validation than in the server
-                            if (user_library[item] == undefined) {
-                                user_library[item] = standard_library[library_type][item];
+                            if (user_library_data[item] == undefined) {
+                                console.log('added missing library item `', item, '` to user library ',
+                                            user_library.type, ' ', user_library.name);
+                                user_library_data[item] = standard_library[library_type][item];
                                 library_changed = true;
                             }
                         }
                     }
-                    if (library_changed === true) {
+                    if (library_changed) {
                         var library_string = JSON.stringify(user_library);
                         library_string = library_string.replace(/&/g, 'and');
                         $.ajax({
@@ -243,8 +245,8 @@ $d = $path . "Modules/assessment/";
                           data: JSON.stringify({'data': library_string}),
                           datatype: "json",
                           contentType: "application/json;charset=utf-8",
-                          success: function (result) {
-                                console.log("Library: " + library_type + ' - ' + result);
+                          success: function (response) {
+                                console.log("updated library: " + library_type);
                           }});
                     }
                 }

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -428,7 +428,7 @@ $d = $path . "Modules/assessment/";
 // ORGANISATIONS
 // ----------------------------------------------------------------------------
     var myorganisations = {};
-    $.ajax({url: path + "assessment/getorganisations.json", success: function (result) {
+    $.ajax({url: apiURL + "/organisations/", success: function (result) {
             myorganisations = result;
             draw_organisation_list();
             //draw_organisation(8);

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -442,14 +442,22 @@ $d = $path . "Modules/assessment/";
         if (orgname == "") {
             alert("Organisation name missing");
         } else {
-            $.ajax({url: path + "assessment/neworganisation.json", data: "orgname=" + orgname, success: function (result) {
-                    if (result.success) {
-                        myorganisations = result.myorganisations;
+            $.ajax({
+                type: 'POST',
+                url: apiURL + "/organisations/",
+                data: {"name": orgname},
+                dataType: 'json',
+                contentType: "application/json;charset=utf-8",
+                success: function (response) {
+                    $.ajax({url: apiURL + "/organisations/", success: function (result) {
+                        myorganisations = result;
                         draw_organisation_list();
-                    } else {
-                        alert(result.message);
-                    }
-                }});
+                    }});
+                },
+                error: function (response) {
+                    alert(response.responseJSON.detail);
+                },
+            });
         }
     });
     $("#organisation-add-member").click(function () {

--- a/mhep-emoncms/projects.php
+++ b/mhep-emoncms/projects.php
@@ -429,7 +429,11 @@ $d = $path . "Modules/assessment/";
 // ----------------------------------------------------------------------------
     var myorganisations = {};
     $.ajax({url: apiURL + "/organisations/", success: function (result) {
-            myorganisations = result;
+            for (let i = 0; i < result.length; i++) {
+                const org = result[i];
+                org.orgid = org.id;
+                myorganisations[org.id] = org;
+            }
             draw_organisation_list();
             //draw_organisation(8);
         }});

--- a/mhep-emoncms/view.php
+++ b/mhep-emoncms/view.php
@@ -3,11 +3,6 @@ global $path, $app_color, $app_title, $app_description, $MHEP_image_gallery;
 
 $d = $path . "Modules/assessment/";
 $projectid = (int) $_GET['id'];
-
-if (is_null($args["openBEM_version"]))
-    $openBEM_version = "10.1.0";  // first version of the model since we started recording it
-else
-    $openBEM_version = $args["openBEM_version"];
 ?>       
 
 <!--<link href='http://fonts.googleapis.com/css?family=Ubuntu:300' rel='stylesheet' type='text/css'>-->
@@ -18,8 +13,8 @@ else
 <script language="javascript" type="text/javascript" src="<?php echo $d; ?>js/ui-mhep.js"></script>
 
 <script language="javascript" type="text/javascript" src="<?php echo $d; ?>js/library-r6.js"></script>
-<script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/gh/carboncoop/openBEM@<?php echo $openBEM_version; ?>/datasets.js"></script>
-<script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/gh/carboncoop/openBEM@<?php echo $openBEM_version; ?>/openBEM.js"></script>
+<script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/gh/carboncoop/openBEM@10.1.1/datasets.js"></script>
+<script language="javascript" type="text/javascript" src="https://cdn.jsdelivr.net/gh/carboncoop/openBEM@10.1.1/openBEM.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $d; ?>js/targetbar-r3.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $d; ?>js/arrow-r3.js"></script>
 <script language="javascript" type="text/javascript" src="<?php echo $d; ?>js/library-helper/library-helper-r1.js"></script>

--- a/mhep-emoncms/views/librariesmanager.js
+++ b/mhep-emoncms/views/librariesmanager.js
@@ -32,7 +32,7 @@ function librariesmanager_UpdateUI()
             $('#libraries-table [library-name="template"]').attr('library-name', library.name);
             $('#libraries-table [library-id="template"]').attr('library-id', library.id);
             $("#libraries-table [library-type='template']").attr('library-type', library.type);
-            if (library_helper.library_permissions[library.id].write != 1) {
+            if (!library.writeable) {
                 access = "Read";
                 $('.if-write-access[library-id=' + library.id + ']').hide('fast');
             }

--- a/mhep-emoncms/views/openBEM_version.js
+++ b/mhep-emoncms/views/openBEM_version.js
@@ -5,10 +5,11 @@ function openBEM_version_UpdateUI()
 }
 
 function openBEM_version_initUI() {
-    if (p.openBEM_version == undefined)
+    if (p.openbem_version == undefined) {
         $('#model-version').html("10.1.0");
-    else
-        $('#model-version').html(p.openBEM_version);
+    } else {
+        $('#model-version').html(p.openbem_version);
+    }
 
     $.ajax({type: 'GET', url: "https://api.github.com/repos/carboncoop/openBEM/releases", success: function (data) {
             data.forEach(function (release) {
@@ -20,9 +21,10 @@ function openBEM_version_initUI() {
 
 
 $('#openbem').on('click', '#apply-version', function () {
-    p.openBEM_version = $('#releases').val();
-    mhep_helper.set_openBEM_version(p.id, p.openBEM_version, function (result) {
-        if (result != false)
+    p.openbem_version = $('#releases').val();
+    mhep_helper.set_openBEM_version(p.id, p.openbem_version, function (result) {
+        if (result != false) {
             location.reload();
+        }
     });
 });


### PR DESCRIPTION
This merge points the emoncms frontend at the Django endpoints. It has been tested to ensure that a user can 

It has been manually tested to ensure you can:

* Create an assessment (set name & description)
* Change the status of an assessment
* Update assessment (change name & description)
* Delete an assessment
* Save data in assessment (e.g. by adding floors, entering values in UI)
* Create a new scenario
* Add an item from a library e.g. a wall
* From within an assessment:
  * Create new item in library (based on empty & based on copy)
  * Edit an item in a library
  * Delete an item from a library
  * Create a new library (based on empty & based on copy)
* From Libraries manager:
  * Show the items in a library
  * Create new item in library (based on empty & based on copy)
  * Edit an item in a library (savelibrary.json)
  * Delete an item from a library
  * Create a new library (based on empty & based on copy)
  * Edit a library (name)
  * Delete a library
* Add a fuel in Fuels manager
* Change the openBEM version after the assessment is created (default should be 10.1.1)
* Export project data to text box
* Import project data from text box
* Download project data to file
* Upload project data from file

The following capabilities have not been tested, as the first release of the Django backend does not support multiple users, organisations, images, or exporting PDFs:

* Create an organisation
* Create an assessment in an organisation
* Share an assessment
* Do anything with image gallery
* Do anything with PDF reports
* Share library
* Do anything with an account (change profile, log out etc)
* Manage users in Libraries manager

# Re-routing calls

It re-routes the following calls:

## Assessments

* `assessment/list.json`

* `assessment/create`
* `assessment/get`
* `assessment/setnameanddescription`
* `assessment/setopenBEMversion`
* `assessment/setstatus`
* `assessment/setdata`
* `assessment/delete`

## Organisations

* `assessment/getorganisations`
* `assessment/neworganisation` (untested)

We shim the new call to `/organisations` to return the org.id as a key.

## Libraries

* `assessment/loaduserlibraries`
* `assessment/newlibrary`
* `assessment/savelibrary`
* `assessment/copylibrary`
* `assessment/setlibraryname`
* `assessment/deletelibrary`

* `assessment/additemtolibrary`
* `assessment/edititeminlibrary`
* `assessment/deletelibraryitem`

Library persmissions are no longer managed by `libraryHelper.library_permissions`, and instead are defined by an argument (`writeable`) on each item in `libraryHelper.libraries`.

This merge also improves the way the user's library is synchronised with the standard library.

# Notes

These changes meant that in some cases the front-end expected JSON strings, where now we returing JSON dictionaries, so it's no longer necessary to call `JSON.parse` on the results.

The openBEM version is no longer flipped in PHP, and we expect the API to return the correct version.

This merge also disables all other PHP JSON endpoints, making it clearer what else will need to be ported.
