### PR TITLE
send CSRF token with every AJAX request

### DIFF
--- a/mhep/config/settings/base.py
+++ b/mhep/config/settings/base.py
@@ -201,8 +201,10 @@ FIXTURE_DIRS = (str(APPS_DIR.path("fixtures")),)
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#session-cookie-httponly
 SESSION_COOKIE_HTTPONLY = True
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#csrf-cookie-httponly
-CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_HTTPONLY = False
+
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-browser-xss-filter
 SECURE_BROWSER_XSS_FILTER = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#x-frame-options

--- a/mhep/mhep/templates/base.html
+++ b/mhep/mhep/templates/base.html
@@ -17,6 +17,8 @@
 
     <script src="{% static 'js/jquery-1.11.3.min.js' %}"></script>
 
+    {% include "js/add_csrf_token_to_ajax.js" %}
+
     {% block css %}
 
     <link href="{% static 'css/bootstrap.css' %}" rel="stylesheet">

--- a/mhep/mhep/templates/js/add_csrf_token_to_ajax.js
+++ b/mhep/mhep/templates/js/add_csrf_token_to_ajax.js
@@ -1,0 +1,31 @@
+<script>
+  function getCookie(name) {
+    var cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      var cookies = document.cookie.split(';');
+      for (var i = 0; i < cookies.length; i++) {
+        var cookie = cookies[i].trim();
+        // Does this cookie string begin with the name we want?
+        if (cookie.substring(0, name.length + 1) === (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+
+  function csrfSafeMethod(method) {
+    // these HTTP methods do not require CSRF protection
+    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+  }
+
+  $.ajaxSetup({
+    beforeSend: function(xhr, settings) {
+      if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+        var csrftoken = getCookie('csrftoken');
+        xhr.setRequestHeader("{{ settings.CSRF_HEADER_NAME }}", csrftoken);
+      }
+    }
+  });
+</script>


### PR DESCRIPTION
add a javascript snippet which loads the CSRF cookie set by Django and
configures jquery to add it as a header to every outgoing AJAX request (in the
header specified by settings.CSRF_HEADER_NAME)

https://docs.djangoproject.com/en/2.2/ref/csrf/#ajax