### PR TITLE
implement "list my organisations" endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ An administrative interface is available at [localhost:9090/admin](http://localh
 * [Create assessment](#create-assessment)
 * [Update a field on assessment](#update-a-field-on-assessment)
 * [Delete assessment](#delete-assessment)
+* [List organisations](#list-organisations)
 * [List libraries](#list-libraries)
 * [Create a library](#create-a-library)
 * [Update a library](#update-a-library)
@@ -235,6 +236,60 @@ Returns:
 
 ```
 HTTP 204 No content
+```
+
+## List organisations
+
+```
+GET /organisations/
+```
+
+List all organisations the current user is a member of.
+
+ℹ️ porting notes: replaces previous `assessment/getorganisations` route.
+
+### Example
+
+```
+GET /organisations/
+```
+
+Returns:
+
+```
+HTTP 200 OK
+Content-Type: application/json
+[
+    {
+        "id": "1",
+        "name": "Chigley Community Energy",
+        "assessments": 0,
+        "members": [
+            {
+                "userid": "2",
+                "name": "janedoe",
+                "lastactive": "?"
+            }
+        ]
+    },
+    {
+        "id": "2",
+        "name": "Sandford Assessment CIC",
+        "assessments": 1,
+        "members": [
+            {
+                "userid": "2",
+                "name": "janedoe",
+                "lastactive": "?"
+            },
+            {
+                "userid": "3",
+                "name": "michael2",
+                "lastactive": "?"
+            }
+        ]
+    }
+]
 ```
 
 ## List libraries

--- a/mhep/mhep/assessments/serializers.py
+++ b/mhep/mhep/assessments/serializers.py
@@ -1,7 +1,7 @@
 import datetime
 
 from rest_framework import serializers
-from mhep.assessments.models import Assessment, Library
+from mhep.assessments.models import Assessment, Library, Organisation
 
 
 class HardcodedAuthorUserIDMixin():
@@ -102,3 +102,31 @@ class LibrarySerializer(StringIDMixin, serializers.ModelSerializer):
 class LibraryItemSerializer(serializers.Serializer):
     tag = serializers.CharField(max_length=100)
     item = serializers.DictField(allow_empty=False)
+
+
+class OrganisationSerializer(StringIDMixin, serializers.ModelSerializer):
+    id = serializers.SerializerMethodField()
+    assessments = serializers.SerializerMethodField()
+    members = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Organisation
+        fields = [
+            "id",
+            "name",
+            "assessments",
+            "members",
+        ]
+
+    def get_assessments(self, obj):
+        return obj.assessments.count()
+
+    def get_members(self, obj):
+        def userinfo(user):
+            return {
+                "userid": f"{user.id}",
+                "name": user.username,
+                "lastactive": "?",
+            }
+
+        return [userinfo(u) for u in obj.members.all()]

--- a/mhep/mhep/assessments/tests/factories.py
+++ b/mhep/mhep/assessments/tests/factories.py
@@ -24,8 +24,14 @@ class LibraryFactory(DjangoModelFactory):
 
 
 class OrganisationFactory(DjangoModelFactory):
-    "Creates an Organisation with 1 member and 1 assessment"
     name = Faker("company")
+
+    class Meta:
+        model = Organisation
+
+
+class OrganisationWithExtrasFactory(OrganisationFactory):
+    "Creates an Organisation with 1 member and 1 assessment"
 
     @post_generation
     def assessments(self, create: bool, extracted: Sequence[Any], **kwargs):
@@ -35,6 +41,3 @@ class OrganisationFactory(DjangoModelFactory):
     def members(self, create: bool, extracted: Sequence[Any], **kwargs):
         from mhep.users.tests.factories import UserFactory
         self.members.add(UserFactory.create())
-
-    class Meta:
-        model = Organisation

--- a/mhep/mhep/assessments/tests/test_models.py
+++ b/mhep/mhep/assessments/tests/test_models.py
@@ -5,5 +5,5 @@ from mhep.assessments.models import Organisation
 pytestmark = pytest.mark.django_db
 
 
-def test_organisation_assessments(organisation: Organisation):
-    assert organisation.assessments.all().count() == 1
+def test_organisation_assessments(organisation_with_extras: Organisation):
+    assert organisation_with_extras.assessments.all().count() == 1

--- a/mhep/mhep/assessments/tests/test_urls.py
+++ b/mhep/mhep/assessments/tests/test_urls.py
@@ -74,12 +74,12 @@ def test_update_destroy_library_item(library: Library):
     )
 
 
-def test_list_create_organisations():
+def test_list_organisations():
     assert (
-        reverse("assessments:list-create-organisations") == "/api/v1/organisations/"
+        reverse("assessments:list-organisations") == "/api/v1/organisations/"
     )
     assert (
-        resolve("/api/v1/organisations/").view_name == "assessments:list-create-organisations"
+        resolve("/api/v1/organisations/").view_name == "assessments:list-organisations"
     )
 
 

--- a/mhep/mhep/assessments/tests/views/test_dummy_organisation_endpoints.py
+++ b/mhep/mhep/assessments/tests/views/test_dummy_organisation_endpoints.py
@@ -26,36 +26,3 @@ class TestListOrganisationAssessments(APITestCase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert None is response.data
-
-
-class TestListCreateOrganisations(APITestCase):
-    def test_list_organisations(self):
-        response = self.client.get("/api/v1/organisations/")
-        assert response.status_code == status.HTTP_200_OK
-
-        expected = [
-            {
-                "id": "1",
-                "name": "Carbon Coop",
-                "assessments": 0,
-                "members": [
-                    {
-                        "userid": "1",
-                        "name": "localadmin",
-                        "lastactive": "?"
-                    }
-                ]
-            }
-        ]
-
-        assert expected == response.data
-
-    def test_create_organisation(self):
-        new_organisation = {
-            "name": "new organisation",
-        }
-
-        response = self.client.post("/api/v1/organisations/", new_organisation, format="json")
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert {"detail": "function not implemented"} == response.data

--- a/mhep/mhep/assessments/tests/views/test_list_organisations.py
+++ b/mhep/mhep/assessments/tests/views/test_list_organisations.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from mhep.assessments.tests.factories import AssessmentFactory, OrganisationFactory
+from mhep.users.tests.factories import UserFactory
+
+
+class TestListOrganisations(APITestCase):
+    def test_shows_logged_in_users_organisations(self):
+        me = UserFactory.create()
+        my_org = OrganisationFactory.create()
+        AssessmentFactory.create(owner=me, organisation=my_org)
+        AssessmentFactory.create(owner=me, organisation=my_org)
+        my_org.members.add(me)
+
+        OrganisationFactory.create()  # make another organisation: it shouldn't show up
+
+        self.client.force_authenticate(me)
+        response = self.client.get("/api/v1/organisations/")
+        assert response.status_code == status.HTTP_200_OK
+
+        expected = [
+            OrderedDict([
+                ("id", f"{my_org.id}"),
+                ("name", my_org.name),
+                ("assessments", 2),
+                ("members", [
+                    {
+                        "userid": f"{me.id}",
+                        "name": me.username,
+                        "lastactive": "?"
+                    }
+                ]),
+            ]),
+        ]
+
+        assert expected == response.data
+
+    def test_returns_forbidden_if_not_logged_in(self):
+        response = self.client.get("/api/v1/organisations/")
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/mhep/mhep/assessments/urls.py
+++ b/mhep/mhep/assessments/urls.py
@@ -8,7 +8,7 @@ from mhep.assessments.views import (
     ListCreateAssessments,
     ListCreateLibraries,
     ListCreateOrganisationAssessments,
-    ListCreateOrganisations,
+    ListOrganisations,
     RetrieveUpdateDestroyAssessment,
     SubviewHTMLView,
     SubviewJavascriptView,
@@ -79,8 +79,8 @@ urlpatterns = [
 
     path(
         "api/v1/organisations/",
-        view=ListCreateOrganisations.as_view(),
-        name="list-create-organisations"
+        view=ListOrganisations.as_view(),
+        name="list-organisations"
     ),
     path(
         "api/v1/organisations/<int:pk>/assessments/",

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -16,6 +16,7 @@ from mhep.assessments.serializers import (
     AssessmentMetadataSerializer,
     LibraryItemSerializer,
     LibrarySerializer,
+    OrganisationSerializer,
 )
 
 
@@ -106,28 +107,12 @@ class UpdateDestroyLibrary(
             return response
 
 
-class ListCreateOrganisations(APIView):
-    def get(self, request, *args, **kwargs):
-        return Response([
-            {
-                "id": "1",
-                "name": "Carbon Coop",
-                "assessments": 0,
-                "members": [
-                    {
-                        "userid": "1",
-                        "name": "localadmin",
-                        "lastactive": "?"
-                    }
-                ]
-            }
-        ], status.HTTP_200_OK)
+class ListOrganisations(generics.ListAPIView):
+    serializer_class = OrganisationSerializer
+    permission_classes = [IsAuthenticated]
 
-    def post(self, request, *args, **kwargs):
-        return Response(
-            {"detail": "function not implemented"},
-            status.HTTP_400_BAD_REQUEST
-        )
+    def get_queryset(self, *args, **kwargs):
+        return self.request.user.organisations.all()
 
 
 class CreateLibraryItem(

--- a/mhep/mhep/conftest.py
+++ b/mhep/mhep/conftest.py
@@ -3,7 +3,12 @@ from django.conf import settings
 from django.test import RequestFactory
 
 from mhep.users.tests.factories import UserFactory, UserWithOrganisationFactory
-from mhep.assessments.tests.factories import AssessmentFactory, LibraryFactory, OrganisationFactory
+from mhep.assessments.tests.factories import (
+    AssessmentFactory,
+    LibraryFactory,
+    OrganisationFactory,
+    OrganisationWithExtrasFactory,
+)
 from mhep.assessments.models import Assessment, Library, Organisation
 
 
@@ -40,3 +45,8 @@ def library() -> Library:
 @pytest.fixture
 def organisation() -> Organisation:
     return OrganisationFactory()
+
+
+@pytest.fixture
+def organisation_with_extras() -> Organisation:
+    return OrganisationWithExtrasFactory()


### PR DESCRIPTION
previously we had a dummy list-create-organisation endpoint. i've dropped
the "create" aspect for now and made an endpoint which lists the
organisations of the logged in user.

* README: add docs for "list organisations"
* split OrganisationFactory (add OrganisationWithExtrasFactory). now,
  OrganisationFactory makes an Organisation with no members and no assessments.
  OrganisationWithExtrasFactory makes an Organisation and adds a member (User)
  and an Assessment