### PR TITLE
don't print test coverage report to screen

### DIFF
--- a/mhep/pytest.ini
+++ b/mhep/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ds=config.settings.test --cov=.
+addopts = --ds=config.settings.test --cov=. --cov-report=


### PR DESCRIPTION
it makes the test output unreadable