### PR TITLE
Guard assessment html view

### DIFF
--- a/mhep/mhep/assessments/tests/views/test_assessment_html_view.py
+++ b/mhep/mhep/assessments/tests/views/test_assessment_html_view.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+
+from rest_framework import status
+
+from mhep.assessments.tests.factories import AssessmentFactory
+from mhep.users.tests.factories import UserFactory
+
+
+class TestAssessmentHTMLView(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.me = UserFactory()
+        cls.me.set_password("foo")
+        cls.me.save()
+        cls.my_assessment = AssessmentFactory.create(owner=cls.me)
+
+    def test_logged_out_users_get_redirected_to_log_in(self):
+        login_url = '/accounts/login/'
+        my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
+        response = self.client.get(my_assessment_url)
+        self.assertRedirects(response, f"{login_url}?next={my_assessment_url}")
+
+    def test_returns_204_for_logged_in_user_viewing_own_assessment(self):
+        self.client.login(username=self.me.username, password="foo")
+        my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
+        response = self.client.get(my_assessment_url)
+        assert status.HTTP_200_OK == response.status_code
+
+    def test_returns_not_found_if_not_owner(self):
+        someone_else = UserFactory.create()
+        someone_else.set_password("foo")
+        someone_else.save()
+        someone_elses_assessment = AssessmentFactory.create(owner=someone_else)
+
+        self.client.login(username=self.me.username, password="foo")
+        not_my_assessment_url = f"/assessments/{someone_elses_assessment.pk}/"
+        response = self.client.get(not_my_assessment_url)
+        assert status.HTTP_404_NOT_FOUND == response.status_code

--- a/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
@@ -220,3 +220,14 @@ class TestAssessmentHTMLView(TestCase):
         my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
         response = self.client.get(my_assessment_url)
         assert status.HTTP_200_OK == response.status_code
+
+    def test_returns_not_found_if_not_owner(self):
+        someone_else = UserFactory.create()
+        someone_else.set_password("foo")
+        someone_else.save()
+        someone_elses_assessment = AssessmentFactory.create(owner=someone_else)
+
+        self.client.login(username=self.me.username, password="foo")
+        not_my_assessment_url = f"/assessments/{someone_elses_assessment.pk}/"
+        response = self.client.get(not_my_assessment_url)
+        assert status.HTTP_404_NOT_FOUND == response.status_code

--- a/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
@@ -198,36 +198,3 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
         assert b"" == response.content
 
         assert (assessment_count - 1) == Assessment.objects.count()
-
-
-class TestAssessmentHTMLView(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.me = UserFactory()
-        cls.me.set_password("foo")
-        cls.me.save()
-        cls.my_assessment = AssessmentFactory.create(owner=cls.me)
-
-    def test_logged_out_users_get_redirected_to_log_in(self):
-        login_url = '/accounts/login/'
-        my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
-        response = self.client.get(my_assessment_url)
-        self.assertRedirects(response, f"{login_url}?next={my_assessment_url}")
-
-    def test_returns_204_for_logged_in_user_viewing_own_assessment(self):
-        self.client.login(username=self.me.username, password="foo")
-        my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
-        response = self.client.get(my_assessment_url)
-        assert status.HTTP_200_OK == response.status_code
-
-    def test_returns_not_found_if_not_owner(self):
-        someone_else = UserFactory.create()
-        someone_else.set_password("foo")
-        someone_else.save()
-        someone_elses_assessment = AssessmentFactory.create(owner=someone_else)
-
-        self.client.login(username=self.me.username, password="foo")
-        not_my_assessment_url = f"/assessments/{someone_elses_assessment.pk}/"
-        response = self.client.get(not_my_assessment_url)
-        assert status.HTTP_404_NOT_FOUND == response.status_code

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -29,6 +29,9 @@ class AssessmentHTMLView(LoginRequiredMixin, DetailView):
     context_object_name = "assessment"
     model = Assessment
 
+    def get_queryset(self, *args, **kwargs):
+        return Assessment.objects.filter(owner=self.request.user)
+
     def get_context_data(self, object=None, **kwargs):
         context = super().get_context_data(**kwargs)
 

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
 
@@ -23,7 +24,7 @@ class BadRequest(exceptions.APIException):
     status_code = status.HTTP_400_BAD_REQUEST
 
 
-class AssessmentHTMLView(DetailView):
+class AssessmentHTMLView(LoginRequiredMixin, DetailView):
     template_name = "assessments/view.html"
     context_object_name = "assessment"
     model = Assessment


### PR DESCRIPTION
Ensure `AssessmentHTMLView` requires a logged in user, and that they are trying to view their own assessment.