### PR TITLE
save `owner` from current user in "create assessment"

### DIFF
--- a/mhep/mhep/assessments/serializers.py
+++ b/mhep/mhep/assessments/serializers.py
@@ -4,12 +4,12 @@ from rest_framework import serializers
 from mhep.assessments.models import Assessment, Library, Organisation
 
 
-class HardcodedAuthorUserIDMixin():
+class AuthorUserIDMixin():
     def get_author(self, obj):
-        return "localadmin"
+        return obj.owner.username
 
     def get_userid(self, obj):
-        return "1"
+        return "{:d}".format(obj.owner.id)
 
 
 class StringIDMixin():
@@ -27,7 +27,7 @@ class MdateMixin():
 class AssessmentMetadataSerializer(
         MdateMixin,
         StringIDMixin,
-        HardcodedAuthorUserIDMixin,
+        AuthorUserIDMixin,
         serializers.ModelSerializer):
 
     author = serializers.SerializerMethodField()
@@ -54,7 +54,7 @@ class AssessmentMetadataSerializer(
 class AssessmentFullSerializer(
         MdateMixin,
         StringIDMixin,
-        HardcodedAuthorUserIDMixin,
+        AuthorUserIDMixin,
         serializers.ModelSerializer):
 
     author = serializers.SerializerMethodField()

--- a/mhep/mhep/assessments/serializers.py
+++ b/mhep/mhep/assessments/serializers.py
@@ -55,17 +55,10 @@ class AssessmentMetadataSerializer(
         ]
 
 
-class AssessmentFullSerializer(
-        MdateMixin,
-        StringIDMixin,
-        AuthorUserIDMixin,
-        serializers.ModelSerializer):
-
-    author = serializers.SerializerMethodField()
-    userid = serializers.SerializerMethodField()
-    id = serializers.SerializerMethodField()
-    mdate = serializers.SerializerMethodField()
-
+class AssessmentFullSerializer(AssessmentMetadataSerializer):
+    """
+    Identical to AssessmentMetadataSerializer except that it includes the `data` field"
+    """
     class Meta:
         model = Assessment
         fields = [

--- a/mhep/mhep/assessments/serializers.py
+++ b/mhep/mhep/assessments/serializers.py
@@ -35,6 +35,10 @@ class AssessmentMetadataSerializer(
     id = serializers.SerializerMethodField()
     mdate = serializers.SerializerMethodField()
 
+    def create(self, validated_data):
+        validated_data['owner'] = self.context['request'].user
+        return super().create(validated_data)
+
     class Meta:
         model = Assessment
         fields = [

--- a/mhep/mhep/assessments/tests/views/test_list_create_assessments.py
+++ b/mhep/mhep/assessments/tests/views/test_list_create_assessments.py
@@ -40,7 +40,7 @@ class TestListAssessments(APITestCase):
 
         assert 2 == len(response.data)
 
-        expectedFirstResult = {
+        expected_first_result = {
             "id": "{}".format(a1.pk),
             "created_at": "2019-06-01T16:35:34Z",
             "updated_at": "2019-06-01T16:35:34Z",
@@ -49,11 +49,11 @@ class TestListAssessments(APITestCase):
             "openbem_version": "10.1.1",
             "name": "test assessment 1",
             "description": "test description",
-            "author": "localadmin",
-            "userid": "1",
+            "author": user.username,
+            "userid": f"{user.id}",
         }
 
-        assert expectedFirstResult == response.data[0]
+        assert expected_first_result == response.data[0]
 
     def test_only_returns_assessments_for_logged_in_user(self):
         user = get_or_create_user("testuser")
@@ -120,8 +120,8 @@ class TestCreateAssessment(APITestCase):
                 "openbem_version": "10.1.1",
                 "name": "test assessment 1",
                 "description": "test description 2",
-                "author": "localadmin",
-                "userid": "1",
+                "author": self.user.username,
+                "userid": f"{self.user.id}",
             }
 
             assert "id" in response.data
@@ -147,8 +147,8 @@ class TestCreateAssessment(APITestCase):
                 "openbem_version": "10.1.1",
                 "name": "test assessment 1",
                 "description": "",
-                "author": "localadmin",
-                "userid": "1",
+                "author": self.user.username,
+                "userid": f"{self.user.id}",
             }
 
             assert "id" in response.data
@@ -177,8 +177,8 @@ class TestCreateAssessment(APITestCase):
             "openbem_version": "10.1.1",
             "name": "test assessment",
             "description": "",
-            "author": "localadmin",
-            "userid": "1",
+            "author": self.user.username,
+            "userid": f"{self.user.id}",
         }
 
         assert "id" in response.data

--- a/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
@@ -12,6 +12,11 @@ from mhep.users.tests.factories import UserFactory
 
 class TestRetrieveUpdateDestroyAssessment(APITestCase):
     @classmethod
+    def setUpClass(cls):
+        cls.me = UserFactory.create()
+        super().setUpClass()
+
+    @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         Assessment.objects.all().delete()
@@ -19,6 +24,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_get_assessment(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     description="test description",
                     data={"foo": "bar"},
@@ -38,8 +44,8 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
             "openbem_version": "10.1.1",
             "name": "test name",
             "description": "test description",
-            "author": "localadmin",
-            "userid": "1",
+            "author": self.me.username,
+            "userid": f"{self.me.id}",
             "data": {"foo": "bar"},
         }
         assert expected == response.data
@@ -47,6 +53,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_get_assessment_without_data_gets_sensible_default(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     openbem_version="10.1.1",
             )
@@ -63,8 +70,8 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
             "name": "test name",
             # defaults:
             "description": "",
-            "author": "localadmin",
-            "userid": "1",
+            "author": self.me.username,
+            "userid": f"{self.me.id}",
             "status": "In progress",
             "data": {},
         }
@@ -77,6 +84,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_update_assessment(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     description="test description",
                     data={"foo": "bar"},
@@ -109,6 +117,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_update_assessment_data_fails_if_string(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     description="test description",
                     data={"foo": "bar"},
@@ -137,6 +146,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_update_assessment_data_fails_if_assessment_is_complete(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     description="test description",
                     data={"foo": "bar"},
@@ -161,6 +171,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
     def test_assessment_status_can_change_from_complete_to_in_progress(self):
         with freeze_time("2019-06-01T16:35:34Z"):
             a = Assessment.objects.create(
+                    owner=self.me,
                     name="test name",
                     description="test description",
                     data={"foo": "bar"},
@@ -183,6 +194,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_destroy_assessment(self):
         a = Assessment.objects.create(
+                owner=self.me,
                 name="test name",
                 description="test description",
                 data={"foo": "bar"},


### PR DESCRIPTION
don't hard-code the `author` and `userid` fields any more

also, AssessmentFullSerializer: inherit, don't repeat