### PR TITLE
list/create/update/delete Library: only allow owner

### DIFF
--- a/mhep/mhep/assessments/models/library.py
+++ b/mhep/mhep/assessments/models/library.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.conf import settings
 from django.db import models
 from django.contrib.postgres.fields import JSONField

--- a/mhep/mhep/assessments/tests/views/test_create_library_item.py
+++ b/mhep/mhep/assessments/tests/views/test_create_library_item.py
@@ -2,12 +2,17 @@
 from freezegun import freeze_time
 
 from rest_framework.test import APITestCase
-from rest_framework import exceptions, status
+from rest_framework import status
 
 from mhep.assessments.tests.factories import LibraryFactory
+from mhep.users.tests.factories import UserFactory
 
 
 class TestCreateLibraryItem(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.me = UserFactory.create()
 
     def test_create_library_item(self):
         library = LibraryFactory.create(data={"tag1": {"name": "foo"}})
@@ -19,12 +24,12 @@ class TestCreateLibraryItem(APITestCase):
             }
         }
 
-        with freeze_time("2019-06-01T16:35:34Z"):
-            response = self.client.post(
-                f"/api/v1/libraries/{library.id}/items/",
-                item_data,
-                format="json"
-            )
+        self.client.force_authenticate(self.me)
+        response = self.client.post(
+            f"/api/v1/libraries/{library.id}/items/",
+            item_data,
+            format="json"
+        )
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -38,6 +43,7 @@ class TestCreateLibraryItem(APITestCase):
             }
         }
 
+        self.client.force_authenticate(self.me)
         response = self.client.post(
             f"/api/v1/libraries/{library.id}/items/",
             item_data,

--- a/mhep/mhep/assessments/tests/views/test_library_permissions.py
+++ b/mhep/mhep/assessments/tests/views/test_library_permissions.py
@@ -1,0 +1,110 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from mhep.assessments.tests.factories import LibraryFactory
+from mhep.users.tests.factories import UserFactory
+
+
+class CommonMixin():
+    def _assert_error(self, response, expected_status, expected_detail):
+        assert expected_status == response.status_code
+        assert {"detail": expected_detail} == response.json()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.library = LibraryFactory.create()
+
+
+class TestCreateLibraryPermissions(CommonMixin, APITestCase):
+    def test_authenticated_user_can_create_a_library(self):
+        person = UserFactory.create()
+
+        self.client.force_authenticate(person)
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_201_CREATED == response.status_code
+
+    def test_unauthenticated_user_cannot_create_a_library(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def _call_endpoint(self, library):
+        new_library = {
+            "name": "test library 1",
+            "type": "test type 1",
+            "data": {"foo": "bar"}
+        }
+
+        return self.client.post("/api/v1/libraries/", new_library, format="json")
+
+
+class TestUpdateLibraryPermissions(CommonMixin, APITestCase):
+    def test_owner_can_update_library(self):
+        self.client.force_authenticate(self.library.owner)
+
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+    def test_unauthenticated_user_cannot_update_library(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def test_user_who_isnt_owner_cannot_update_library(self):
+        non_owner = UserFactory.create()
+        self.client.force_authenticate(non_owner)
+
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            "Not found.",
+        )
+
+    def _call_endpoint(self, library):
+        update_fields = {
+            "data": {"new": "data"},
+        }
+
+        return self.client.patch(
+            "/api/v1/libraries/{}/".format(library.id),
+            update_fields,
+            format="json",
+        )
+
+
+class TestDeleteLibraryPermissions(CommonMixin, APITestCase):
+    def test_owner_can_delete_library(self):
+        self.client.force_authenticate(self.library.owner)
+
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+    def test_unauthenticated_user_cannot_delete_library(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def test_user_who_isnt_owner_cannot_delete_library(self):
+        non_owner = UserFactory.create()
+        self.client.force_authenticate(non_owner)
+
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            "Not found.",
+        )
+
+    def _call_endpoint(self, library):
+        return self.client.delete("/api/v1/libraries/{}/".format(library.id))

--- a/mhep/mhep/assessments/tests/views/test_list_create_libraries.py
+++ b/mhep/mhep/assessments/tests/views/test_list_create_libraries.py
@@ -18,6 +18,7 @@ class TestListCreateLibraries(APITestCase):
         with freeze_time("2019-06-01T16:35:34Z"):
             l1 = LibraryFactory.create(owner=self.me)
             l2 = LibraryFactory.create(owner=self.me)
+            LibraryFactory.create(owner=UserFactory.create())  # another library (someone else's)
 
         self.client.force_authenticate(self.me)
         response = self.client.get("/api/v1/libraries/")

--- a/mhep/mhep/assessments/tests/views/test_update_destroy_library_item.py
+++ b/mhep/mhep/assessments/tests/views/test_update_destroy_library_item.py
@@ -6,13 +6,14 @@ from rest_framework import status
 
 from mhep.assessments.models import Library
 from mhep.assessments.tests.factories import LibraryFactory
+from mhep.users.tests.factories import UserFactory
 
 
 class TestUpdateDestroyLibraryItem(APITestCase):
     @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        Library.objects.all().delete()
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.me = UserFactory.create()
 
     def test_destroy_library_item(self):
         library = LibraryFactory.create(
@@ -22,6 +23,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
             },
         )
 
+        self.client.force_authenticate(self.me)
         response = self.client.delete(f"/api/v1/libraries/{library.id}/items/tag2/")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -42,6 +44,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
         }
 
         with freeze_time("2019-06-01T16:35:34Z"):
+            self.client.force_authenticate(self.me)
             response = self.client.put(
                 f"/api/v1/libraries/{library.id}/items/tag1/",
                 replacement_data,
@@ -60,11 +63,12 @@ class TestUpdateDestroyLibraryItem(APITestCase):
             "other": "data",
         }
 
-        with freeze_time("2019-06-01T16:35:34Z"):
-            response = self.client.put(
-                f"/api/v1/libraries/{library.id}/items/tag5/",
-                replacement_data,
-                format="json"
-            )
+        self.client.force_authenticate(self.me)
+
+        response = self.client.put(
+            f"/api/v1/libraries/{library.id}/items/tag5/",
+            replacement_data,
+            format="json"
+        )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -106,8 +106,15 @@ class UpdateDestroyLibrary(
     generics.UpdateAPIView,
     generics.DestroyAPIView,
 ):
-    queryset = Library.objects.all()
     serializer_class = LibrarySerializer
+    permission_classes = [
+        # IsAuthenticated will ensure we can filter (using get_queryset) based on User.libraries
+        # (which is the reverse of Library.owner)
+        IsAuthenticated,
+    ]
+
+    def get_queryset(self, *args, **kwargs):
+        return self.request.user.libraries.all()
 
     def update(self, request, *args, **kwargs):
         response = super().update(request, *args, **kwargs)

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -95,9 +95,11 @@ class RetrieveUpdateDestroyAssessment(
 
 
 class ListCreateLibraries(generics.ListCreateAPIView):
-    queryset = Library.objects.all()
     serializer_class = LibrarySerializer
     permission_classes = [IsAuthenticated]
+
+    def get_queryset(self, *args, **kwargs):
+        return self.request.user.libraries.all()
 
 
 class UpdateDestroyLibrary(


### PR DESCRIPTION
* create / list / update / delete library: require that user is logged in, and filter based on
  whether they are the owner
* update library tests: use force_authenticate to fix tests
* list libraries: test we filter out other users' libraries