### PR TITLE
Refactor the tests for retrieve, update destroy assessment

### DIFF
--- a/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
@@ -26,11 +26,11 @@ class TestGetAssessment(APITestCase):
             )
 
         self.client.force_authenticate(self.me)
-        response = self.client.get("/api/v1/assessments/{}/".format(a.pk))
+        response = self.client.get(f"/api/v1/assessments/{a.pk}/")
         assert response.status_code == status.HTTP_200_OK
 
         expected = {
-            "id": "{}".format(a.pk),
+            "id": f"{a.pk}",
             "created_at": "2019-06-01T16:35:34Z",
             "updated_at": "2019-06-01T16:35:34Z",
             "mdate": "1559406934",
@@ -55,7 +55,7 @@ class TestGetAssessment(APITestCase):
             )
 
         self.client.force_authenticate(self.me)
-        response = self.client.get("/api/v1/assessments/{}/".format(a.pk))
+        response = self.client.get(f"/api/v1/assessments/{a.pk}/")
         assert response.status_code == status.HTTP_200_OK
 
         expected = {
@@ -75,7 +75,7 @@ class TestGetAssessment(APITestCase):
         assert expected == response.data
 
     def test_returns_404_for_bad_id(self):
-        response = self.client.get("/api/v1/assessments/{}/".format("bad-id"))
+        response = self.client.get("/api/v1/assessments/bad-id/")
         assert status.HTTP_404_NOT_FOUND == response.status_code
 
 

--- a/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/assessments/tests/views/test_retrieve_update_destroy_assessment.py
@@ -14,14 +14,9 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
         cls.me = UserFactory.create()
         super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-        Assessment.objects.all().delete()
-
     def test_get_assessment(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     description="test description",
@@ -51,10 +46,12 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_get_assessment_without_data_gets_sensible_default(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     openbem_version="10.1.1",
+                    description="",
+                    data={},
             )
 
         self.client.force_authenticate(self.me)
@@ -83,7 +80,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_update_assessment(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     description="test description",
@@ -117,7 +114,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_update_assessment_data_fails_if_string(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     description="test description",
@@ -146,7 +143,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_update_assessment_data_fails_if_assessment_is_complete(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     description="test description",
@@ -172,7 +169,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
 
     def test_assessment_status_can_change_from_complete_to_in_progress(self):
         with freeze_time("2019-06-01T16:35:34Z"):
-            a = Assessment.objects.create(
+            a = AssessmentFactory.create(
                     owner=self.me,
                     name="test name",
                     description="test description",
@@ -196,7 +193,7 @@ class TestRetrieveUpdateDestroyAssessment(APITestCase):
         assert status.HTTP_204_NO_CONTENT == response.status_code
 
     def test_destroy_assessment(self):
-        a = Assessment.objects.create(
+        a = AssessmentFactory.create(
                 owner=self.me,
                 name="test name",
                 description="test description",


### PR DESCRIPTION
Specifically:

* break apart TestRetrieveUpdateDestroyAssessment into into seperate verb test classes, and name the functions to make them clearer
* use AssessmentFactory instead of Assessment.create
* use f instead of format