### PR TITLE
enforce permissions for create, update, delete library items

### DIFF
--- a/mhep/mhep/assessments/permissions.py
+++ b/mhep/mhep/assessments/permissions.py
@@ -3,7 +3,7 @@ from rest_framework import exceptions, permissions
 from mhep.assessments.models import Organisation
 
 
-class IsOwner(permissions.BasePermission):
+class IsAssessmentOwner(permissions.BasePermission):
     # https://www.django-rest-framework.org/api-guide/permissions/#custom-permissions
     message = "You are not the owner of the Assessment."
 

--- a/mhep/mhep/assessments/permissions.py
+++ b/mhep/mhep/assessments/permissions.py
@@ -11,6 +11,13 @@ class IsOwner(permissions.BasePermission):
         return request.user == assessment.owner
 
 
+class IsLibraryOwner(permissions.BasePermission):
+    message = "You are not the owner of the Library."
+
+    def has_object_permission(self, request, view, library):
+        return request.user == library.owner
+
+
 class IsMemberOfConnectedOrganisation(permissions.BasePermission):
     message = "You are not a member of the Assessment's Organisation."
 

--- a/mhep/mhep/assessments/tests/views/test_library_item_permissions.py
+++ b/mhep/mhep/assessments/tests/views/test_library_item_permissions.py
@@ -1,0 +1,129 @@
+from rest_framework.test import APITestCase
+from rest_framework import status
+
+from mhep.assessments.tests.factories import LibraryFactory
+from mhep.users.tests.factories import UserFactory
+
+
+class CommonMixin():
+    def _assert_error(self, response, expected_status, expected_detail):
+        assert expected_status == response.status_code
+        assert {"detail": expected_detail} == response.json()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.library = LibraryFactory.create(data={
+            "tag1": {"name": "foo"},
+            "tag2": {"name": "bar"},
+        })
+
+
+class TestCreateLibraryItemPermissions(CommonMixin, APITestCase):
+    def test_owner_can_create_library_item(self):
+        self.client.force_authenticate(self.library.owner)
+
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+    def test_unauthenticated_user_cannot_create_library_item(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def test_user_who_isnt_owner_cannot_create_library_item(self):
+        non_owner = UserFactory.create()
+        self.client.force_authenticate(non_owner)
+
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            "Not found.",
+        )
+
+    def _call_endpoint(self, library):
+        item_data = {
+            "tag": "new_tag",
+            "item": {
+                "name": "bar",
+            }
+        }
+
+        return self.client.post(
+            f"/api/v1/libraries/{self.library.id}/items/",
+            item_data,
+            format="json"
+        )
+
+
+class TestUpdateLibraryItemPermissions(CommonMixin, APITestCase):
+    def test_owner_can_update_library(self):
+        self.client.force_authenticate(self.library.owner)
+
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+    def test_unauthenticated_user_cannot_update_library_item(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def test_user_who_isnt_owner_cannot_update_library_item(self):
+        non_owner = UserFactory.create()
+        self.client.force_authenticate(non_owner)
+
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            "Not found.",
+        )
+
+    def _call_endpoint(self, library):
+        replacement_data = {
+            "name": "bar",
+            "other": "data",
+        }
+
+        return self.client.put(
+            f"/api/v1/libraries/{self.library.id}/items/tag1/",
+            replacement_data,
+            format="json"
+        )
+
+
+class TestDeleteLibraryItemPermissions(CommonMixin, APITestCase):
+    def test_owner_can_delete_library_item(self):
+        self.client.force_authenticate(self.library.owner)
+
+        response = self._call_endpoint(self.library)
+        assert status.HTTP_204_NO_CONTENT == response.status_code
+
+    def test_unauthenticated_user_cannot_delete_library_item(self):
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
+        )
+
+    def test_user_who_isnt_owner_cannot_delete_library_item(self):
+        non_owner = UserFactory.create()
+        self.client.force_authenticate(non_owner)
+
+        response = self._call_endpoint(self.library)
+        self._assert_error(
+            response,
+            status.HTTP_404_NOT_FOUND,
+            "Not found.",
+        )
+
+    def _call_endpoint(self, library):
+        return self.client.delete(f"/api/v1/libraries/{self.library.id}/items/tag2/")

--- a/mhep/mhep/assessments/tests/views/test_update_destroy_library_item.py
+++ b/mhep/mhep/assessments/tests/views/test_update_destroy_library_item.py
@@ -6,15 +6,9 @@ from rest_framework import status
 
 from mhep.assessments.models import Library
 from mhep.assessments.tests.factories import LibraryFactory
-from mhep.users.tests.factories import UserFactory
 
 
 class TestUpdateDestroyLibraryItem(APITestCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.me = UserFactory.create()
-
     def test_destroy_library_item(self):
         library = LibraryFactory.create(
             data={
@@ -23,7 +17,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
             },
         )
 
-        self.client.force_authenticate(self.me)
+        self.client.force_authenticate(library.owner)
         response = self.client.delete(f"/api/v1/libraries/{library.id}/items/tag2/")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -44,7 +38,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
         }
 
         with freeze_time("2019-06-01T16:35:34Z"):
-            self.client.force_authenticate(self.me)
+            self.client.force_authenticate(library.owner)
             response = self.client.put(
                 f"/api/v1/libraries/{library.id}/items/tag1/",
                 replacement_data,
@@ -63,7 +57,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
             "other": "data",
         }
 
-        self.client.force_authenticate(self.me)
+        self.client.force_authenticate(library.owner)
 
         response = self.client.put(
             f"/api/v1/libraries/{library.id}/items/tag5/",

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -15,6 +15,7 @@ from mhep.assessments.permissions import (
     IsMemberOfConnectedOrganisation,
     IsMemberOfOrganisation,
     IsOwner,
+    IsLibraryOwner,
 )
 from mhep.assessments.serializers import (
     AssessmentFullSerializer,
@@ -141,6 +142,10 @@ class CreateLibraryItem(
     generics.GenericAPIView,
 ):
     serializer_class = LibraryItemSerializer
+    permission_classes = [
+        IsAuthenticated,
+        IsLibraryOwner,
+    ]
 
     def get_queryset(self, *args, **kwargs):
         return self.request.user.libraries.all()
@@ -177,6 +182,10 @@ class UpdateDestroyLibraryItem(
     generics.GenericAPIView,
 ):
     serializer_class = LibraryItemSerializer
+    permission_classes = [
+        IsAuthenticated,
+        IsLibraryOwner,
+    ]
 
     def get_queryset(self, *args, **kwargs):
         return self.request.user.libraries.all()

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -14,7 +14,7 @@ from mhep.assessments.models import Assessment, Library, Organisation
 from mhep.assessments.permissions import (
     IsMemberOfConnectedOrganisation,
     IsMemberOfOrganisation,
-    IsOwner,
+    IsAssessmentOwner,
     IsLibraryOwner,
 )
 from mhep.assessments.serializers import (
@@ -80,7 +80,7 @@ class RetrieveUpdateDestroyAssessment(
     serializer_class = AssessmentFullSerializer
     permission_classes = [
         IsAuthenticated,
-        IsOwner | IsMemberOfConnectedOrganisation,
+        IsAssessmentOwner | IsMemberOfConnectedOrganisation,
     ]
 
     def update(self, request, *args, **kwargs):

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -142,6 +142,9 @@ class CreateLibraryItem(
 ):
     serializer_class = LibraryItemSerializer
 
+    def get_queryset(self, *args, **kwargs):
+        return self.request.user.libraries.all()
+
     def post(self, request, pk):
         serializer = self.get_serializer_class()(data=request.data)
         if not serializer.is_valid():
@@ -151,7 +154,7 @@ class CreateLibraryItem(
         tag = serializer.validated_data['tag']
         item = serializer.validated_data['item']
 
-        library = Library.objects.get(id=pk)
+        library = self.get_object()
 
         if isinstance(library.data, str):
             d = json.loads(library.data)
@@ -175,8 +178,11 @@ class UpdateDestroyLibraryItem(
 ):
     serializer_class = LibraryItemSerializer
 
+    def get_queryset(self, *args, **kwargs):
+        return self.request.user.libraries.all()
+
     def delete(self, request, pk, tag):
-        library = Library.objects.get(id=pk)
+        library = self.get_object()
 
         if isinstance(library.data, str):
             d = json.loads(library.data)
@@ -192,7 +198,7 @@ class UpdateDestroyLibraryItem(
         return Response("", status=status.HTTP_204_NO_CONTENT)
 
     def put(self, request, pk, tag):
-        library = Library.objects.get(id=pk)
+        library = self.get_object()
 
         if isinstance(library.data, str):
             d = json.loads(library.data)


### PR DESCRIPTION
* update library item tests to authenticate as owner
* add tests for library item permissions
* library item: use permissions class IsLibraryOwner
* use self.get_object(), not Library.objects.get: it means we get DRF's object
  permissions checking for free, provided we've defined a queryset.
* rename IsOwner -> IsAssessmentOwner (vs IsLibraryOwner)