### PR TITLE
don't implement own logout view

### DIFF
--- a/mhep/mhep/assessments/urls.py
+++ b/mhep/mhep/assessments/urls.py
@@ -14,7 +14,6 @@ from mhep.assessments.views import (
     SubviewHTMLView,
     SubviewJavascriptView,
     UpdateDestroyLibrary,
-    logout_view,
 )
 
 app_name = "assessments"
@@ -100,5 +99,4 @@ urlpatterns = [
         view=CreateUpdateDeleteLibraryItem.as_view(),
         name="create-update-delete-library-item"
     ),
-    url(r'^logout', logout_view, name='logout'),
 ]

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -2,7 +2,6 @@ import json
 import logging
 
 from django.contrib import messages
-from django.contrib.auth import logout
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect
 from django.views.generic import DetailView
@@ -241,9 +240,3 @@ class ListCreateOrganisationAssessments(generics.ListCreateAPIView):
 
 class ListAssessmentsHTMLView(LoginRequiredMixin, TemplateView):
     template_name = "assessments/assessments.html"
-
-
-def logout_view(request):
-    logout(request)
-    messages.info(request, "Logged out successfully!")
-    return redirect("assessments:home")

--- a/mhep/mhep/templates/base.html
+++ b/mhep/mhep/templates/base.html
@@ -69,7 +69,7 @@
 			CARBON COOP (DJANGO)
 		  </div>
       {% if user.is_authenticated %}
-          <a style="display: inline" class="menu-assessment pull-right" href="{% url 'assessments:logout' %}" >Log out</a>
+          <a style="display: inline" class="menu-assessment pull-right" href="{% url 'account_logout' %}" >Log out</a>
       {% endif %}
 		</div>
 	  </div>


### PR DESCRIPTION
the `allauth` module is already providing a log-out view (called
`account_logout`)

Here's where we import allauth's URLs:

https://github.com/mhep-transition/mhep-django/blob/master/mhep/config/urls.py#L16

Here are the docs for all of allauth's views:

https://django-allauth.readthedocs.io/en/latest/views.html