### PR TITLE
Fix it so that members of organisations can view assessments in their organisations

### DIFF
--- a/mhep/mhep/assessments/tests/views/test_assessment_html_view.py
+++ b/mhep/mhep/assessments/tests/views/test_assessment_html_view.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from rest_framework import status
 
-from mhep.assessments.tests.factories import AssessmentFactory
+from mhep.assessments.tests.factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 
 
@@ -47,6 +47,19 @@ class TestAssessmentHTMLView(TestCase):
         self.client.login(username=self.me.username, password="foo")
         my_assessment_url = "/assessments/{}/".format(self.my_assessment.pk)
         response = self.client.get(my_assessment_url)
+        assert status.HTTP_200_OK == response.status_code
+
+
+    def test_returns_200_for_organisation_member_viewing_assessment_in_organisation(self):
+        organisation = OrganisationFactory.create()
+        organisation_assessment = AssessmentFactory.create(
+            organisation=organisation,
+        )
+        organisation.members.add(self.me)
+
+        self.client.login(username=self.me.username, password="foo")
+        not_my_assessment_url = f"/assessments/{organisation_assessment.pk}/"
+        response = self.client.get(not_my_assessment_url)
         assert status.HTTP_200_OK == response.status_code
 
     def test_returns_not_found_if_not_owner(self):

--- a/mhep/mhep/assessments/tests/views/test_assessment_permissions.py
+++ b/mhep/mhep/assessments/tests/views/test_assessment_permissions.py
@@ -10,10 +10,8 @@ class AssessmentPermissionTestsMixin():
         assessment = AssessmentFactory.create()
         self.client.force_authenticate(assessment.owner)
 
-        self.call_endpoint_and_assert(
-            assessment,
-            True,
-        )
+        response = self._call_endpoint(assessment)
+        self._assert_success(response)
 
     def test_organisation_member_who_isnt_owner_can_access(self):
         organisation = OrganisationFactory.create()
@@ -24,19 +22,17 @@ class AssessmentPermissionTestsMixin():
 
         self.client.force_authenticate(org_member)
 
-        self.call_endpoint_and_assert(
-            assessment,
-            True,
-        )
+        response = self._call_endpoint(assessment)
+        self._assert_success(response)
 
     def test_unauthenticated_user_cannot_access(self):
         assessment = AssessmentFactory.create()
 
-        self.call_endpoint_and_assert(
-            assessment,
-            False,
-            "Authentication credentials were not provided.",
+        response = self._call_endpoint(assessment)
+        self._assert_error(
+            response,
             status.HTTP_403_FORBIDDEN,
+            "Authentication credentials were not provided.",
         )
 
     def test_user_who_isnt_owner_and_isnt_organisation_member_cannot_access(self):
@@ -46,62 +42,53 @@ class AssessmentPermissionTestsMixin():
 
         self.client.force_authenticate(non_owner)
 
-        self.call_endpoint_and_assert(
-            assessment,
-            False,
-            "Not found.",
+        response = self._call_endpoint(assessment)
+        self._assert_error(
+            response,
             status.HTTP_404_NOT_FOUND,
+            "Not found.",
         )
 
 
 class TestGetAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
-    def call_endpoint_and_assert(self, assessment, expect_permit, *args):
-        response = self.client.get("/api/v1/assessments/{}/".format(assessment.id))
+    def _call_endpoint(self, assessment):
+        return self.client.get("/api/v1/assessments/{}/".format(assessment.id))
 
-        if expect_permit:
-            assert status.HTTP_200_OK == response.status_code
+    def _assert_success(self, response):
+        assert status.HTTP_200_OK == response.status_code
 
-        if len(args) > 0:
-            expected_error_detail = args[0]
-            assert {"detail": expected_error_detail} == response.json()
-        if len(args) > 1:
-            expected_status_code = args[1]
-            assert expected_status_code == response.status_code
+    def _assert_error(self, response, expected_status_code, expected_error_detail):
+        assert expected_status_code == response.status_code
+        assert {"detail": expected_error_detail} == response.json()
 
 
 class TestUpdateAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
-    def call_endpoint_and_assert(self, assessment, expect_permit, *args):
+    def _call_endpoint(self, assessment):
         update_fields = {
             "data": {"new": "data"},
         }
 
-        response = self.client.patch(
+        return self.client.patch(
             "/api/v1/assessments/{}/".format(assessment.id),
             update_fields,
             format="json",
         )
 
-        if expect_permit:
-            assert status.HTTP_204_NO_CONTENT == response.status_code
+    def _assert_success(self, response):
+        assert status.HTTP_204_NO_CONTENT == response.status_code
 
-        if len(args) > 0:
-            expected_error_detail = args[0]
-            assert {"detail": expected_error_detail} == response.json()
-        if len(args) > 1:
-            expected_status_code = args[1]
-            assert expected_status_code == response.status_code
+    def _assert_error(self, response, expected_status_code, expected_error_detail):
+        assert expected_status_code == response.status_code
+        assert {"detail": expected_error_detail} == response.json()
 
 
 class TestDeleteAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
-    def call_endpoint_and_assert(self, assessment, expect_permit, *args):
-        response = self.client.delete("/api/v1/assessments/{}/".format(assessment.id))
+    def _call_endpoint(self, assessment):
+        return self.client.delete("/api/v1/assessments/{}/".format(assessment.id))
 
-        if expect_permit:
-            assert status.HTTP_204_NO_CONTENT == response.status_code
+    def _assert_success(self, response):
+        assert status.HTTP_204_NO_CONTENT == response.status_code
 
-        if len(args) > 0:
-            expected_error_detail = args[0]
-            assert {"detail": expected_error_detail} == response.json()
-        if len(args) > 1:
-            expected_status_code = args[1]
-            assert expected_status_code == response.status_code
+    def _assert_error(self, response, expected_status_code, expected_error_detail):
+        assert expected_status_code == response.status_code
+        assert {"detail": expected_error_detail} == response.json()

--- a/mhep/mhep/assessments/tests/views/test_assessment_permissions.py
+++ b/mhep/mhep/assessments/tests/views/test_assessment_permissions.py
@@ -36,6 +36,7 @@ class AssessmentPermissionTestsMixin():
             assessment,
             False,
             "Authentication credentials were not provided.",
+            status.HTTP_403_FORBIDDEN,
         )
 
     def test_user_who_isnt_owner_and_isnt_organisation_member_cannot_access(self):
@@ -48,7 +49,8 @@ class AssessmentPermissionTestsMixin():
         self.call_endpoint_and_assert(
             assessment,
             False,
-            "You do not have permission to perform this action."
+            "Not found.",
+            status.HTTP_404_NOT_FOUND,
         )
 
 
@@ -58,12 +60,13 @@ class TestGetAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
 
         if expect_permit:
             assert status.HTTP_200_OK == response.status_code
-        else:
-            assert status.HTTP_403_FORBIDDEN == response.status_code
 
         if len(args) > 0:
             expected_error_detail = args[0]
             assert {"detail": expected_error_detail} == response.json()
+        if len(args) > 1:
+            expected_status_code = args[1]
+            assert expected_status_code == response.status_code
 
 
 class TestUpdateAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
@@ -80,12 +83,13 @@ class TestUpdateAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCas
 
         if expect_permit:
             assert status.HTTP_204_NO_CONTENT == response.status_code
-        else:
-            assert status.HTTP_403_FORBIDDEN == response.status_code
 
         if len(args) > 0:
             expected_error_detail = args[0]
             assert {"detail": expected_error_detail} == response.json()
+        if len(args) > 1:
+            expected_status_code = args[1]
+            assert expected_status_code == response.status_code
 
 
 class TestDeleteAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
@@ -94,9 +98,10 @@ class TestDeleteAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCas
 
         if expect_permit:
             assert status.HTTP_204_NO_CONTENT == response.status_code
-        else:
-            assert status.HTTP_403_FORBIDDEN == response.status_code
 
         if len(args) > 0:
             expected_error_detail = args[0]
             assert {"detail": expected_error_detail} == response.json()
+        if len(args) > 1:
+            expected_status_code = args[1]
+            assert expected_status_code == response.status_code

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -1,9 +1,7 @@
 import json
 import logging
 
-from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import redirect
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
 
@@ -12,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
 
-from mhep.assessments.models import Assessment, Library, Organisation
+from mhep.assessments.models import Assessment, Organisation
 from mhep.assessments.permissions import (
     IsMemberOfConnectedOrganisation,
     IsMemberOfOrganisation,

--- a/mhep/mhep/assessments/views.py
+++ b/mhep/mhep/assessments/views.py
@@ -26,17 +26,23 @@ from mhep.assessments.serializers import (
 )
 
 
+class AssessmentQuerySetMixin():
+    def get_queryset(self, *args, **kwargs):
+        my_assessments = Assessment.objects.filter(owner=self.request.user)
+        assessments_in_my_organisations = Assessment.objects.filter(
+            organisation__in=self.request.user.organisations.all()
+        )
+        return my_assessments | assessments_in_my_organisations
+
+
 class BadRequest(exceptions.APIException):
     status_code = status.HTTP_400_BAD_REQUEST
 
 
-class AssessmentHTMLView(LoginRequiredMixin, DetailView):
+class AssessmentHTMLView(AssessmentQuerySetMixin, LoginRequiredMixin, DetailView):
     template_name = "assessments/view.html"
     context_object_name = "assessment"
     model = Assessment
-
-    def get_queryset(self, *args, **kwargs):
-        return Assessment.objects.filter(owner=self.request.user)
 
     def get_context_data(self, object=None, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -74,9 +80,9 @@ class ListCreateAssessments(
 
 
 class RetrieveUpdateDestroyAssessment(
+    AssessmentQuerySetMixin,
     generics.RetrieveUpdateDestroyAPIView,
 ):
-    queryset = Assessment.objects.all()
     serializer_class = AssessmentFullSerializer
     permission_classes = [
         IsAuthenticated,


### PR DESCRIPTION
Previously if a member of an organisation attempted to view an assessment in their organisation, `AssessmentHTMLView` threw 404, as it was using only the logged in users own assessments as its query set.

This pull request introduces a new mixin `AssessmentQuerySetMixin`, used now in both `AssessmentHTMLView` and `RetrieveUpdateDestroyAssessment` (to standardise their behaviour). This mixin defines the `get_queryset` function, ensuring that it returns all assessments the user owns *and* all assessments in the organisations the user is a member of.

This required an update to the tests, as these were previously relying on the `permission_class` `IsMemberOfConnectedOrganisation` to guard against viewing an assessment you weren't in the organisation. Since this is now handled by `get_queryset` it returns 404, rather than 403.

This pull request also adds a new test to pin this behaviour.