### PR TITLE
remove hardcoded `v1`s from inside the v1 app

### DIFF
--- a/mhep/mhep/v1/__init__.py
+++ b/mhep/mhep/v1/__init__.py
@@ -1,0 +1,3 @@
+from os.path import basename, dirname
+
+VERSION = basename(dirname(__file__))  # for example, `v1`

--- a/mhep/mhep/v1/admin.py
+++ b/mhep/mhep/v1/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.db import models
 from django.forms import CheckboxSelectMultiple
 
-from mhep.v1.models import Assessment, Library, Organisation
+from .models import Assessment, Library, Organisation
 
 
 @admin.register(Assessment)

--- a/mhep/mhep/v1/apps.py
+++ b/mhep/mhep/v1/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
+from . import VERSION
 
 
 class AssessmentsConfig(AppConfig):
-    name = 'mhep.v1'
-    verbose_name = "Assessments v1"
+    name = f"mhep.{VERSION}"
+    verbose_name = f"Assessments {VERSION}"

--- a/mhep/mhep/v1/models/assessment.py
+++ b/mhep/mhep/v1/models/assessment.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField
-from mhep.v1.validators import validate_dict
+from ..validators import validate_dict
 
 STATUS_CHOICES = [
         ('Complete', 'Complete'),

--- a/mhep/mhep/v1/models/library.py
+++ b/mhep/mhep/v1/models/library.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
 from django.contrib.postgres.fields import JSONField
-from mhep.v1.validators import validate_dict
+from ..validators import validate_dict
 
 
 class Library(models.Model):

--- a/mhep/mhep/v1/permissions.py
+++ b/mhep/mhep/v1/permissions.py
@@ -1,6 +1,6 @@
 from rest_framework import exceptions, permissions
 
-from mhep.v1.models import Organisation
+from .models import Organisation
 
 
 class IsAssessmentOwner(permissions.BasePermission):

--- a/mhep/mhep/v1/serializers.py
+++ b/mhep/mhep/v1/serializers.py
@@ -1,7 +1,7 @@
 import datetime
 
 from rest_framework import serializers
-from mhep.v1.models import Assessment, Library, Organisation
+from .models import Assessment, Library, Organisation
 
 
 class AuthorUserIDMixin():

--- a/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
+++ b/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
@@ -265,7 +265,7 @@ libraryHelper.prototype.append_modals = function () {
     var html;
     var myself = this;
     $.ajax({
-        url: urlHelper.static('v1/js/library-helper/library-helper.html'),
+        url: urlHelper.static('js/library-helper/library-helper.html'),
         datatype: "json",
         error: handleServerError('loading library helper HTML'),
         success: function (result) {

--- a/mhep/mhep/v1/static/v1/js/ui-helper-r3.js
+++ b/mhep/mhep/v1/static/v1/js/ui-helper-r3.js
@@ -10,7 +10,7 @@ function load_view(eid, view)
 
     var result_html = "";
     $.ajax({
-        url: urlHelper.static('v1/subviews/' + view + '.html'),
+        url: urlHelper.static('subviews/' + view + '.html'),
         async: false,
         cache: false,
         error: handleServerError('loading HTML for subview "' + view + '"'),
@@ -23,7 +23,7 @@ function load_view(eid, view)
 
     // Load js
     $.ajax({
-        url: urlHelper.static('v1/subviews/' + view + '.js'),
+        url: urlHelper.static('subviews/' + view + '.js'),
         dataType: 'script',
         async: false,
         error: handleServerError('loading Javascript for subview "' + view + '"'),

--- a/mhep/mhep/v1/static/v1/subviews/commentary.js
+++ b/mhep/mhep/v1/static/v1/subviews/commentary.js
@@ -8,7 +8,7 @@ function commentary_UpdateUI()
 function commentary_initUI() {
     // The commentary was originally in "Household Questionnaire", we need to for several reasons we need to initilize it
     $.ajax({
-        url: urlHelper.static('v1/subviews/householdquestionnaire.js'),
+        url: urlHelper.static('subviews/householdquestionnaire.js'),
         dataType: 'script',
         async: false,
         error: handleServerError('loading householdquestionnaire.js'),

--- a/mhep/mhep/v1/static/v1/subviews/elements.js
+++ b/mhep/mhep/v1/static/v1/subviews/elements.js
@@ -594,7 +594,7 @@ function elements_UpdateUI()
             options += "<option value='" + data.fabric.elements[z].id + "'>" + data.fabric.elements[z].location + "</option>";
     }
 
-    $('.revert-to-original-icon').attr('src', urlHelper.static('v1/img/undo.gif'));
+    $('.revert-to-original-icon').attr('src', urlHelper.static('img/undo.gif'));
 
     // Fill up the substractfrom selects
     $('.subtractfrom').each(function (i, obj) {

--- a/mhep/mhep/v1/static/v1/subviews/householdquestionnaire.js
+++ b/mhep/mhep/v1/static/v1/subviews/householdquestionnaire.js
@@ -1,7 +1,7 @@
 console.log('debug householdquestionnaire.js')
 
 $.ajax({
-    url: urlHelper.static('v1/js/papaparse/papaparse.js'),
+    url: urlHelper.static('js/papaparse/papaparse.js'),
     dataType: 'script',
     async: false,
     error: handleServerError('loading papaparse.js'),

--- a/mhep/mhep/v1/static/v1/subviews/topgraphic.js
+++ b/mhep/mhep/v1/static/v1/subviews/topgraphic.js
@@ -1,5 +1,5 @@
 console.debug("topgraphic.js");
 
-$('image.topgraphic-house').attr('href', urlHelper.static('v1/img/topgraphic/house.svg'));
-$('image.topgraphic-arrow').attr('href', urlHelper.static('v1/img/topgraphic/arrow.svg'));
-$('image.topgraphic-arrow-light').attr('href', urlHelper.static('v1/img/topgraphic/arrow-light.svg'));
+$('image.topgraphic-house').attr('href', urlHelper.static('img/topgraphic/house.svg'));
+$('image.topgraphic-arrow').attr('href', urlHelper.static('img/topgraphic/arrow.svg'));
+$('image.topgraphic-arrow-light').attr('href', urlHelper.static('img/topgraphic/arrow-light.svg'));

--- a/mhep/mhep/v1/static/v1/subviews/ventilation.js
+++ b/mhep/mhep/v1/static/v1/subviews/ventilation.js
@@ -433,7 +433,7 @@ function ventilation_initUI() {
         out += '<td> <button class="apply-ventilation-measure-from-lib if-not-master" type="extract_ventilation_points" item_id="' + item.id + '" style="margin-right:25px">Apply Measure</button>'
         out += '<span class="edit-item-EVP" row="' + z + '" tag="' + item.tag + '" style="cursor:pointer; margin-right:15px" item=\'' + JSON.stringify(item) + '\' title="Editing a system this way is not considered a Measure"> <a><i class = "icon-edit"> </i></a></span>';
         out += '<span class = "delete-EVP" row="' + z + '" style="cursor:pointer" title="Deleting an element this way is not considered a Measure" ><a> <i class="icon-trash" ></i></a></span>';
-        out += '<span class="revert-to-original" item-id="' + item.id + '" item-type="ventilation-EVP" style="margin-left:15px; display:inline-block;cursor: pointer"><img src="' + urlHelper.static('v1/img/undo.gif') + '" style="width:14px" /><span class="text" /></span>';
+        out += '<span class="revert-to-original" item-id="' + item.id + '" item-type="ventilation-EVP" style="margin-left:15px; display:inline-block;cursor: pointer"><img src="' + urlHelper.static('img/undo.gif') + '" style="width:14px" /><span class="text" /></span>';
         out += '</td></tr> ';
         $('#EVP').append(out);
         init_revert_to_original_by_id('#fans_and_vents_div #EVP', item.id, 'ventilation-EVP');

--- a/mhep/mhep/v1/templates/v1/assessments.html
+++ b/mhep/mhep/v1/templates/v1/assessments.html
@@ -1,4 +1,4 @@
-{% extends "v1/mhep_base.html" %}
+{% extends VERSION|add:"/mhep_base.html" %}
 {% load static i18n %}
 
 

--- a/mhep/mhep/v1/templates/v1/assessments.html
+++ b/mhep/mhep/v1/templates/v1/assessments.html
@@ -67,7 +67,7 @@
             <div id="myorganisations"></div>
             {% if request.user.is_staff %}
             <br>
-            <a href="{% url "admin:v1_organisation_changelist" %}">Manage organisations</a>
+            <a href="{% url "admin:"|add:VERSION|add:"_organisation_changelist" %}">Manage organisations</a>
             {% endif %}
         </div>
     </div>

--- a/mhep/mhep/v1/templates/v1/assessments.html
+++ b/mhep/mhep/v1/templates/v1/assessments.html
@@ -455,8 +455,7 @@
     $("body").on("click", ".org-item", function () {
         orgid = $(this).attr("orgid");
         draw_organisation(orgid);
-        edit_org_link = "{% url 'admin:v1_organisation_change' 12345 %}".replace(/12345/, orgid.toString());
-        $("#organisation-add-member").attr("href", edit_org_link);
+        $("#organisation-add-member").attr("href", urlHelper.admin.organisation(orgid));
         $("#organisation").show();
         viewmode = "organisation";
         $.ajax({

--- a/mhep/mhep/v1/templates/v1/assessments.html
+++ b/mhep/mhep/v1/templates/v1/assessments.html
@@ -34,8 +34,8 @@
     }
 </style>
 
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/mhep-helper.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/library-r6.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/mhep-helper.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/library-r6.js' %}"></script>
 
 {% endblock %}
 
@@ -487,7 +487,7 @@
             const lastLogin = new Date(members[z].last_login);
 
             out += "<div class='recent-activity-item' style='height:40px'>";
-            out += '<img src="{% static "v1/img/defaultuser.png" %}" style="height:40px; float:left; padding-right:5px"/ >';
+            out += '<img src="' + urlHelper.static('img/defaultuser.png') + '" style="height:40px; float:left; padding-right:5px"/ >';
             out += "<b>" + members[z].name + "</b><br>Last active: " + lastLogin;
             out += "</div>";
         }

--- a/mhep/mhep/v1/templates/v1/js/url_helper.js
+++ b/mhep/mhep/v1/templates/v1/js/url_helper.js
@@ -54,7 +54,8 @@
 
       static: function (resourcePath) {
         // returns the full URL for the given static file e.g. 'img/graphic.png'
-        return '{% static "12345" %}'.replace(/12345/, resourcePath);
+        const dummyURL = '{% static VERSION|add:"/12345" %}';
+        return dummyURL.replace(/12345/, resourcePath);
       },
 
     }

--- a/mhep/mhep/v1/templates/v1/js/url_helper.js
+++ b/mhep/mhep/v1/templates/v1/js/url_helper.js
@@ -58,6 +58,13 @@
         return dummyURL.replace(/12345/, resourcePath);
       },
 
+      admin: {
+        organisation: function(organisationID) {
+          const dummyURL = '{% url "admin:"|add:VERSION|add:"_organisation_change" 12345 %}';
+          return dummyURL.replace(/12345/, orgid.toString());
+        }
+      },
+
     }
   }();
 </script>

--- a/mhep/mhep/v1/templates/v1/js/url_helper.js
+++ b/mhep/mhep/v1/templates/v1/js/url_helper.js
@@ -10,45 +10,45 @@
     return {
       api: {
         assessments: function() {
-          return '{% url "v1:list-create-assessments" %}';
+          return '{% url VERSION|add:":list-create-assessments" %}';
         },
 
         assessment: function(assessmentID) {
-          const dummyURL = '{% url "v1:retrieve-update-destroy-assessment" "12345" %}';
+          const dummyURL = '{% url VERSION|add:":retrieve-update-destroy-assessment" "12345" %}';
           return dummyURL.replace(/12345/, parseInt(assessmentID));
         },
 
         organisationAssessments: function(organisationID) {
-          const dummyURL = '{% url "v1:list-create-organisation-assessments" "12345" %}';
+          const dummyURL = '{% url VERSION|add:":list-create-organisation-assessments" "12345" %}';
           return dummyURL.replace(/12345/, parseInt(organisationID));
         },
 
         organisations: function() {
-          return '{% url "v1:list-organisations" %}';
+          return '{% url VERSION|add:":list-organisations" %}';
         },
 
         libraries: function() {
-          return '{% url "v1:list-create-libraries" %}';
+          return '{% url VERSION|add:":list-create-libraries" %}';
         },
 
         library: function(libraryID) {
-          return '{% url "v1:update-destroy-library" "12345" %}'.replace(/12345/, parseInt(libraryID));
+          return '{% url VERSION|add:":update-destroy-library" "12345" %}'.replace(/12345/, parseInt(libraryID));
         },
 
         libraryItems: function(libraryID) {
-          const dummyURL = '{% url "v1:create-update-delete-library-item" "12345" %}';
+          const dummyURL = '{% url VERSION|add:":create-update-delete-library-item" "12345" %}';
           return dummyURL.replace(/12345/, parseInt(libraryID));
         },
 
         libraryItem: function(libraryID, tag) {
-          const dummyURL = '{% url "v1:create-update-delete-library-item" "12345" "abcde" %}';
+          const dummyURL = '{% url VERSION|add:":create-update-delete-library-item" "12345" "abcde" %}';
           return dummyURL.replace(/12345/, parseInt(libraryID)).replace(/abcde/, tag);
         },
       },
 
       html: {
         assessment: function(assessmentID) {
-          return '{% url "v1:view-assessment" "12345" %}'.replace(/12345/, assessmentID.toString());
+          return '{% url VERSION|add:":view-assessment" "12345" %}'.replace(/12345/, assessmentID.toString());
         },
       },
 

--- a/mhep/mhep/v1/templates/v1/mhep_base.html
+++ b/mhep/mhep/v1/templates/v1/mhep_base.html
@@ -13,7 +13,7 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
 
-    <script src="{% static 'v1/js/jquery-1.11.3.min.js' %}"></script>
+    <script src="{% static VERSION|add:'/js/jquery-1.11.3.min.js' %}"></script>
 
     {% include "v1/js/handle_server_error.js" %}
     {% include "v1/js/add_csrf_token_to_ajax.js" %}
@@ -21,16 +21,16 @@
 
     {% block css %}
 
-    <link href="{% static 'v1/css/bootstrap.css' %}" rel="stylesheet">
-    <link href="{% static 'v1/css/bootstrap-responsive.min.css' %}" rel="stylesheet">
-    <link href="{% static 'v1/css/emon-blue.css' %}" rel="stylesheet">
-    <link href="{% static 'v1/css/emon-CCoop.css' %}" rel="stylesheet">
+    <link href="{% static VERSION|add:'/css/bootstrap.css' %}" rel="stylesheet">
+    <link href="{% static VERSION|add:'/css/bootstrap-responsive.min.css' %}" rel="stylesheet">
+    <link href="{% static VERSION|add:'/css/emon-blue.css' %}" rel="stylesheet">
+    <link href="{% static VERSION|add:'/css/emon-CCoop.css' %}" rel="stylesheet">
 
     <!-- Your stuff: Third-party CSS libraries go here -->
 
     <!-- This file stores project-specific CSS -->
 
-    <link href="{% static 'v1/css/project.css' %}" rel="stylesheet">
+    <link href="{% static VERSION|add:'/css/project.css' %}" rel="stylesheet">
 
 
     {% endblock %}
@@ -108,12 +108,12 @@
     <!-- Placed at the end of the document so the pages load faster -->
     {% block javascript %}
 
-      <script src="{% static 'v1/js/bootstrap.js' %}"></script>
+      <script src="{% static VERSION|add:'/js/bootstrap.js' %}"></script>
 
 
       <!-- place project specific Javascript in this file -->
 
-      <script src="{% static 'v1/js/project.js' %}"></script>
+      <script src="{% static VERSION|add:'/js/project.js' %}"></script>
 
 
     {% endblock javascript %}

--- a/mhep/mhep/v1/templates/v1/mhep_base.html
+++ b/mhep/mhep/v1/templates/v1/mhep_base.html
@@ -15,9 +15,9 @@
 
     <script src="{% static VERSION|add:'/js/jquery-1.11.3.min.js' %}"></script>
 
-    {% include "v1/js/handle_server_error.js" %}
-    {% include "v1/js/add_csrf_token_to_ajax.js" %}
-    {% include "v1/js/url_helper.js" %}
+    {% include VERSION|add:"/js/handle_server_error.js" %}
+    {% include VERSION|add:"/js/add_csrf_token_to_ajax.js" %}
+    {% include VERSION|add:"/js/url_helper.js" %}
 
     {% block css %}
 

--- a/mhep/mhep/v1/templates/v1/view.html
+++ b/mhep/mhep/v1/templates/v1/view.html
@@ -681,7 +681,7 @@
             scenarios_measures_complete = {}
             if (view_html['compare'] == undefined) {
                 $.ajax({
-                    url: urlHelper.static('v1/subviews/compare.js'),
+                    url: urlHelper.static('subviews/compare.js'),
                     async: false,
                     cache: false,
                     error: handleServerError('loading subview compare.js'),

--- a/mhep/mhep/v1/templates/v1/view.html
+++ b/mhep/mhep/v1/templates/v1/view.html
@@ -2,24 +2,24 @@
 {% load static i18n %}
 
 {% block extra_head %}
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/mhep-helper.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/ui-helper-r3.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/ui-mhep.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/library-r6.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/openbem/datasets.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/openbem/openBEM.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/targetbar-r3.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/arrow-r3.js' %}"></script>
-<script language="javascript" type="text/javascript" src="{% static 'v1/js/library-helper/library-helper.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/mhep-helper.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/ui-helper-r3.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/ui-mhep.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/library-r6.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/openbem/datasets.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/openbem/openBEM.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/targetbar-r3.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/arrow-r3.js' %}"></script>
+<script language="javascript" type="text/javascript" src="{% static VERSION|add:'/js/library-helper/library-helper.js' %}"></script>
 
 
-<link rel="stylesheet" href="{% static 'v1/js/jquery-ui-1.12.1/jquery-ui.min.css' %}">
-<script src="{% static 'v1/js/jquery-ui-1.12.1/jquery-ui.min.js' %}"></script>
+<link rel="stylesheet" href="{% static VERSION|add:'/js/jquery-ui-1.12.1/jquery-ui.min.css' %}">
+<script src="{% static VERSION|add:'/js/jquery-ui-1.12.1/jquery-ui.min.js' %}"></script>
 
 <!-- open floor uvalue calculator -->
-<script type="text/javascript" src="{% static 'v1/js/openFUVC/openFUVC.js' %}"></script>
-<script type="text/javascript" src="{% static 'v1/js/openFUVC/openFUVC-ui-helper.js' %}"></script>
-<link rel="stylesheet" href="{% static 'v1/js/openFUVC/openFUVC.css' %}">
+<script type="text/javascript" src="{% static VERSION|add:'/js/openFUVC/openFUVC.js' %}"></script>
+<script type="text/javascript" src="{% static VERSION|add:'/js/openFUVC/openFUVC-ui-helper.js' %}"></script>
+<link rel="stylesheet" href="{% static VERSION|add:'/js/openFUVC/openFUVC.css' %}">
 
 <style>
     :root {
@@ -288,8 +288,8 @@
     var historical_index; // pointer for the historical array, pointing the current version of project
     historical.unshift(JSON.stringify(project));
     historical_index = 0;
-    $('.navbar-inner').append('<div style="display:inline" class="menu-assessment pull-right" id="redo"><a><img src="{% static "v1/img/redo.gif" %}" title="Redo" style="width:14px" /></a></div>');
-    $('.navbar-inner').append('<div style="display:inline" class="menu-assessment pull-right" id="undo"><a><img src="{% static "v1/img/undo.gif" %}" title="Undo" style="width:14px" / > </a></div> ');
+    $('.navbar-inner').append('<div style="display:inline" class="menu-assessment pull-right" id="redo"><a><img src="{% static VERSION|add:"/img/redo.gif" %}" title="Redo" style="width:14px" /></a></div>');
+    $('.navbar-inner').append('<div style="display:inline" class="menu-assessment pull-right" id="undo"><a><img src="{% static VERSION|add:"/img/undo.gif" %}" title="Undo" style="width:14px" / > </a></div> ');
     refresh_undo_redo_buttons();
 
     //**************************

--- a/mhep/mhep/v1/templates/v1/view.html
+++ b/mhep/mhep/v1/templates/v1/view.html
@@ -1,4 +1,4 @@
-{% extends "v1/mhep_base.html" %}
+{% extends VERSION|add:"/mhep_base.html" %}
 {% load static i18n %}
 
 {% block extra_head %}

--- a/mhep/mhep/v1/tests/factories.py
+++ b/mhep/mhep/v1/tests/factories.py
@@ -2,7 +2,7 @@ import factory
 
 from typing import Any, Sequence
 
-from mhep.v1.models import Assessment, Library, Organisation
+from ..models import Assessment, Library, Organisation
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/test_models.py
+++ b/mhep/mhep/v1/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mhep.v1.models import Organisation
+from ..models import Organisation
 
 pytestmark = pytest.mark.django_db
 

--- a/mhep/mhep/v1/tests/test_urls.py
+++ b/mhep/mhep/v1/tests/test_urls.py
@@ -3,61 +3,62 @@ import pytest
 from django.urls import reverse, resolve
 
 from ..models import Assessment, Library
+from .. import VERSION
 
 pytestmark = pytest.mark.django_db
 
 
 def test_assessments_home():
     assert (
-        reverse("v1:list-assessments") == "/v1/"
+        reverse(f"{VERSION}:list-assessments") == f"/{VERSION}/"
     )
-    assert resolve("/v1/").view_name == "v1:list-assessments"
+    assert resolve(f"/{VERSION}/").view_name == f"{VERSION}:list-assessments"
 
 
 def test_list_create_assessments(assessment: Assessment):
     assert (
-        reverse("v1:list-create-assessments") == "/v1/api/assessments/"
+        reverse(f"{VERSION}:list-create-assessments") == f"/{VERSION}/api/assessments/"
     )
-    assert resolve("/v1/api/assessments/").view_name == "v1:list-create-assessments"
+    assert resolve(f"/{VERSION}/api/assessments/").view_name == f"{VERSION}:list-create-assessments"
 
 
 def test_assessment_detail_update_destroy(assessment: Assessment):
     assert (
-        reverse("v1:retrieve-update-destroy-assessment", kwargs={"pk": assessment.id})
-        == f"/v1/api/assessments/{assessment.id}/"
+        reverse(f"{VERSION}:retrieve-update-destroy-assessment", kwargs={"pk": assessment.id})
+        == f"/{VERSION}/api/assessments/{assessment.id}/"
     )
     assert (
-        resolve(f"/v1/api/assessments/{assessment.id}/").view_name
-        == "v1:retrieve-update-destroy-assessment"
+        resolve(f"/{VERSION}/api/assessments/{assessment.id}/").view_name
+        == f"{VERSION}:retrieve-update-destroy-assessment"
     )
 
 
 def test_list_create_libraries():
     assert (
-        reverse("v1:list-create-libraries") == "/v1/api/libraries/"
+        reverse(f"{VERSION}:list-create-libraries") == f"/{VERSION}/api/libraries/"
     )
-    assert resolve("/v1/api/libraries/").view_name == "v1:list-create-libraries"
+    assert resolve(f"/{VERSION}/api/libraries/").view_name == f"{VERSION}:list-create-libraries"
 
 
 def test_update_destroy_library(library: Library):
     assert (
-        reverse("v1:update-destroy-library", kwargs={"pk": library.id})
-        == f"/v1/api/libraries/{library.id}/"
+        reverse(f"{VERSION}:update-destroy-library", kwargs={"pk": library.id})
+        == f"/{VERSION}/api/libraries/{library.id}/"
     )
     assert (
-        resolve(f"/v1/api/libraries/{library.id}/").view_name
-        == "v1:update-destroy-library"
+        resolve(f"/{VERSION}/api/libraries/{library.id}/").view_name
+        == f"{VERSION}:update-destroy-library"
     )
 
 
 def test_create_library_item(library: Library):
     assert (
-        reverse("v1:create-update-delete-library-item", kwargs={"pk": library.id})
-        == f"/v1/api/libraries/{library.id}/items/"
+        reverse(f"{VERSION}:create-update-delete-library-item", kwargs={"pk": library.id})
+        == f"/{VERSION}/api/libraries/{library.id}/items/"
     )
     assert (
-        resolve(f"/v1/api/libraries/{library.id}/items/").view_name
-        == "v1:create-update-delete-library-item"
+        resolve(f"/{VERSION}/api/libraries/{library.id}/items/").view_name
+        == f"{VERSION}:create-update-delete-library-item"
     )
 
 
@@ -65,30 +66,30 @@ def test_update_destroy_library_item(library: Library):
     tag = "SW_01"
 
     assert (
-        reverse("v1:create-update-delete-library-item", kwargs={"pk": library.id, "tag": tag})
-        == f"/v1/api/libraries/{library.id}/items/{tag}/"
+        reverse(f"{VERSION}:create-update-delete-library-item", kwargs={"pk": library.id, "tag": tag})
+        == f"/{VERSION}/api/libraries/{library.id}/items/{tag}/"
     )
     assert (
-        resolve(f"/v1/api/libraries/{library.id}/items/{tag}/").view_name
-        == "v1:create-update-delete-library-item"
+        resolve(f"/{VERSION}/api/libraries/{library.id}/items/{tag}/").view_name
+        == f"{VERSION}:create-update-delete-library-item"
     )
 
 
 def test_list_organisations():
     assert (
-        reverse("v1:list-organisations") == "/v1/api/organisations/"
+        reverse(f"{VERSION}:list-organisations") == f"/{VERSION}/api/organisations/"
     )
     assert (
-        resolve("/v1/api/organisations/").view_name == "v1:list-organisations"
+        resolve(f"/{VERSION}/api/organisations/").view_name == f"{VERSION}:list-organisations"
     )
 
 
 def test_list_create_organisation_assessments():
     assert (
-        reverse("v1:list-create-organisation-assessments", kwargs={"pk": 1})
-        == "/v1/api/organisations/1/assessments/"
+        reverse(f"{VERSION}:list-create-organisation-assessments", kwargs={"pk": 1})
+        == f"/{VERSION}/api/organisations/1/assessments/"
     )
     assert (
-        resolve("/v1/api/organisations/1/assessments/").view_name
-        == "v1:list-create-organisation-assessments"
+        resolve(f"/{VERSION}/api/organisations/1/assessments/").view_name
+        == f"{VERSION}:list-create-organisation-assessments"
     )

--- a/mhep/mhep/v1/tests/test_urls.py
+++ b/mhep/mhep/v1/tests/test_urls.py
@@ -2,7 +2,7 @@ import pytest
 # from django.conf import settings
 from django.urls import reverse, resolve
 
-from mhep.v1.models import Assessment, Library
+from ..models import Assessment, Library
 
 pytestmark = pytest.mark.django_db
 

--- a/mhep/mhep/v1/tests/views/test_assessment_html_view.py
+++ b/mhep/mhep/v1/tests/views/test_assessment_html_view.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 
 from rest_framework import status
 
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_assessment_html_view.py
+++ b/mhep/mhep/v1/tests/views/test_assessment_html_view.py
@@ -3,7 +3,9 @@ from django.urls import reverse
 
 from rest_framework import status
 
+from ... import VERSION
 from ..factories import AssessmentFactory, OrganisationFactory
+
 from mhep.users.tests.factories import UserFactory
 
 
@@ -18,13 +20,13 @@ class TestListAssessmentsHTMLView(TestCase):
 
     def test_logged_out_users_get_redirected_to_log_in(self):
         login_url = reverse("account_login")
-        my_assessments_url = reverse("v1:list-assessments")
+        my_assessments_url = reverse(f"{VERSION}:list-assessments")
         response = self.client.get(my_assessments_url)
         self.assertRedirects(response, f"{login_url}?next={my_assessments_url}")
 
     def test_returns_200_for_logged_in_user_viewing_own_assessment(self):
         self.client.login(username=self.me.username, password="foo")
-        my_assessments_url = reverse("v1:list-assessments")
+        my_assessments_url = reverse(f"{VERSION}:list-assessments")
         response = self.client.get(my_assessments_url)
         assert status.HTTP_200_OK == response.status_code
 
@@ -40,13 +42,13 @@ class TestAssessmentHTMLView(TestCase):
 
     def test_logged_out_users_get_redirected_to_log_in(self):
         login_url = reverse("account_login")  # '/accounts/login/'
-        my_assessment_url = "/v1/assessments/{}/".format(self.my_assessment.pk)
+        my_assessment_url = f"/{VERSION}/assessments/{self.my_assessment.pk}/"
         response = self.client.get(my_assessment_url)
         self.assertRedirects(response, f"{login_url}?next={my_assessment_url}")
 
     def test_returns_200_for_logged_in_user_viewing_own_assessment(self):
         self.client.login(username=self.me.username, password="foo")
-        my_assessment_url = "/v1/assessments/{}/".format(self.my_assessment.pk)
+        my_assessment_url = f"/{VERSION}/assessments/{self.my_assessment.pk}/"
         response = self.client.get(my_assessment_url)
         assert status.HTTP_200_OK == response.status_code
 
@@ -58,7 +60,7 @@ class TestAssessmentHTMLView(TestCase):
         organisation.members.add(self.me)
 
         self.client.login(username=self.me.username, password="foo")
-        not_my_assessment_url = f"/v1/assessments/{organisation_assessment.pk}/"
+        not_my_assessment_url = f"/{VERSION}/assessments/{organisation_assessment.pk}/"
         response = self.client.get(not_my_assessment_url)
         assert status.HTTP_200_OK == response.status_code
 
@@ -69,6 +71,6 @@ class TestAssessmentHTMLView(TestCase):
         someone_elses_assessment = AssessmentFactory.create(owner=someone_else)
 
         self.client.login(username=self.me.username, password="foo")
-        not_my_assessment_url = f"/v1/assessments/{someone_elses_assessment.pk}/"
+        not_my_assessment_url = f"/{VERSION}/assessments/{someone_elses_assessment.pk}/"
         response = self.client.get(not_my_assessment_url)
         assert status.HTTP_404_NOT_FOUND == response.status_code

--- a/mhep/mhep/v1/tests/views/test_assessment_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_assessment_permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_assessment_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_assessment_permissions.py
@@ -1,8 +1,10 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
+
+from ... import VERSION
+from ..factories import AssessmentFactory, OrganisationFactory
 
 
 class AssessmentPermissionTestsMixin():
@@ -52,7 +54,7 @@ class AssessmentPermissionTestsMixin():
 
 class TestGetAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
     def _call_endpoint(self, assessment):
-        return self.client.get("/v1/api/assessments/{}/".format(assessment.id))
+        return self.client.get(f"/{VERSION}/api/assessments/{assessment.id}/")
 
     def _assert_success(self, response):
         assert status.HTTP_200_OK == response.status_code
@@ -69,7 +71,7 @@ class TestUpdateAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCas
         }
 
         return self.client.patch(
-            "/v1/api/assessments/{}/".format(assessment.id),
+            f"/{VERSION}/api/assessments/{assessment.id}/",
             update_fields,
             format="json",
         )
@@ -84,7 +86,7 @@ class TestUpdateAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCas
 
 class TestDeleteAssessmentPermissions(AssessmentPermissionTestsMixin, APITestCase):
     def _call_endpoint(self, assessment):
-        return self.client.delete("/v1/api/assessments/{}/".format(assessment.id))
+        return self.client.delete(f"/{VERSION}/api/assessments/{assessment.id}/")
 
     def _assert_success(self, response):
         assert status.HTTP_204_NO_CONTENT == response.status_code

--- a/mhep/mhep/v1/tests/views/test_create_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_create_assessments.py
@@ -5,9 +5,10 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
-from mhep.v1.models import Assessment
-from mhep.v1.tests.factories import OrganisationFactory
+from ..factories import OrganisationFactory
+from ...models import Assessment
 from mhep.users.tests.factories import UserFactory
+
 User = get_user_model()
 
 

--- a/mhep/mhep/v1/tests/views/test_create_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_create_assessments.py
@@ -5,9 +5,11 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
-from ..factories import OrganisationFactory
-from ...models import Assessment
 from mhep.users.tests.factories import UserFactory
+
+from ... import VERSION
+from ...models import Assessment
+from ..factories import OrganisationFactory
 
 User = get_user_model()
 
@@ -192,7 +194,7 @@ class CreateAssessmentTestsMixin():
 class TestCreateAssessment(CreateAssessmentTestsMixin, APITestCase):
     def post_to_create_endpoint(self, assessment):
         return self.client.post(
-            "/v1/api/assessments/",
+            f"/{VERSION}/api/assessments/",
             assessment,
             format="json"
         )
@@ -204,7 +206,7 @@ class TestCreateAssessmentForOrganisation(CreateAssessmentTestsMixin, APITestCas
         organisation.members.add(self.user)
 
         return self.client.post(
-            f"/v1/api/organisations/{organisation.pk}/assessments/",
+            f"/{VERSION}/api/organisations/{organisation.pk}/assessments/",
             assessment,
             format="json"
         )
@@ -222,7 +224,7 @@ class TestCreateAssessmentForOrganisation(CreateAssessmentTestsMixin, APITestCas
         }
 
         response = self.client.post(
-            f"/v1/api/organisations/{organisation.pk}/assessments/",
+            f"/{VERSION}/api/organisations/{organisation.pk}/assessments/",
             new_assessment,
             format="json"
         )
@@ -244,7 +246,7 @@ class TestCreateAssessmentForOrganisation(CreateAssessmentTestsMixin, APITestCas
         }
 
         response = self.client.post(
-            f"/v1/api/organisations/{organisation.pk}/assessments/",
+            f"/{VERSION}/api/organisations/{organisation.pk}/assessments/",
             new_assessment,
             format="json"
         )

--- a/mhep/mhep/v1/tests/views/test_create_library_item.py
+++ b/mhep/mhep/v1/tests/views/test_create_library_item.py
@@ -1,6 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
+from ... import VERSION
 from ..factories import LibraryFactory
 
 
@@ -20,7 +21,7 @@ class TestCreateLibraryItem(APITestCase):
 
         self.client.force_authenticate(self.library.owner)
         response = self.client.post(
-            f"/v1/api/libraries/{self.library.id}/items/",
+            f"/{VERSION}/api/libraries/{self.library.id}/items/",
             item_data,
             format="json"
         )
@@ -37,7 +38,7 @@ class TestCreateLibraryItem(APITestCase):
 
         self.client.force_authenticate(self.library.owner)
         response = self.client.post(
-            f"/v1/api/libraries/{self.library.id}/items/",
+            f"/{VERSION}/api/libraries/{self.library.id}/items/",
             item_data,
             format="json"
         )

--- a/mhep/mhep/v1/tests/views/test_create_library_item.py
+++ b/mhep/mhep/v1/tests/views/test_create_library_item.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import LibraryFactory
+from ..factories import LibraryFactory
 
 
 class TestCreateLibraryItem(APITestCase):

--- a/mhep/mhep/v1/tests/views/test_library_item_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_library_item_permissions.py
@@ -1,8 +1,10 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
+
+from ... import VERSION
+from ..factories import LibraryFactory
 
 
 class CommonMixin():
@@ -54,7 +56,7 @@ class TestCreateLibraryItemPermissions(CommonMixin, APITestCase):
         }
 
         return self.client.post(
-            f"/v1/api/libraries/{self.library.id}/items/",
+            f"/{VERSION}/api/libraries/{self.library.id}/items/",
             item_data,
             format="json"
         )
@@ -93,7 +95,7 @@ class TestUpdateLibraryItemPermissions(CommonMixin, APITestCase):
         }
 
         return self.client.put(
-            f"/v1/api/libraries/{self.library.id}/items/tag1/",
+            f"/{VERSION}/api/libraries/{self.library.id}/items/tag1/",
             replacement_data,
             format="json"
         )
@@ -126,4 +128,4 @@ class TestDeleteLibraryItemPermissions(CommonMixin, APITestCase):
         )
 
     def _call_endpoint(self, library):
-        return self.client.delete(f"/v1/api/libraries/{self.library.id}/items/tag2/")
+        return self.client.delete(f"/{VERSION}/api/libraries/{self.library.id}/items/tag2/")

--- a/mhep/mhep/v1/tests/views/test_library_item_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_library_item_permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import LibraryFactory
+from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_library_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_library_permissions.py
@@ -1,8 +1,10 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
+
+from ... import VERSION
+from ..factories import LibraryFactory
 
 
 class CommonMixin():
@@ -39,7 +41,7 @@ class TestCreateLibraryPermissions(CommonMixin, APITestCase):
             "data": {"foo": "bar"}
         }
 
-        return self.client.post("/v1/api/libraries/", new_library, format="json")
+        return self.client.post(f"/{VERSION}/api/libraries/", new_library, format="json")
 
 
 class TestUpdateLibraryPermissions(CommonMixin, APITestCase):
@@ -74,7 +76,7 @@ class TestUpdateLibraryPermissions(CommonMixin, APITestCase):
         }
 
         return self.client.patch(
-            "/v1/api/libraries/{}/".format(library.id),
+            f"/{VERSION}/api/libraries/{library.id}/",
             update_fields,
             format="json",
         )
@@ -107,4 +109,4 @@ class TestDeleteLibraryPermissions(CommonMixin, APITestCase):
         )
 
     def _call_endpoint(self, library):
-        return self.client.delete("/v1/api/libraries/{}/".format(library.id))
+        return self.client.delete(f"/{VERSION}/api/libraries/{library.id}/")

--- a/mhep/mhep/v1/tests/views/test_library_permissions.py
+++ b/mhep/mhep/v1/tests/views/test_library_permissions.py
@@ -1,7 +1,7 @@
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import LibraryFactory
+from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_list_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_list_assessments.py
@@ -5,8 +5,11 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
+from ... import VERSION
 from ..factories import AssessmentFactory, OrganisationFactory
+
 from mhep.users.tests.factories import UserFactory
+
 User = get_user_model()
 
 
@@ -24,7 +27,7 @@ class TestListAssessments(APITestCase):
                     owner=user,
             )
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
 
         expected_structure = {
             "id": "{}".format(a1.pk),
@@ -53,7 +56,7 @@ class TestListAssessments(APITestCase):
 
         AssessmentFactory.create(organisation=organisation)
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_200_OK
 
         assert 2 == len(response.data)
@@ -67,11 +70,11 @@ class TestListAssessments(APITestCase):
         AssessmentFactory.create(owner=me)
         AssessmentFactory.create(owner=someone_else)
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_200_OK
 
         assert 2 == len(response.data)
 
     def test_returns_forbidden_if_not_logged_in(self):
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/mhep/mhep/v1/tests/views/test_list_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_list_assessments.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 User = get_user_model()
 

--- a/mhep/mhep/v1/tests/views/test_list_assessments_for_organisations.py
+++ b/mhep/mhep/v1/tests/views/test_list_assessments_for_organisations.py
@@ -4,7 +4,7 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 
 from mhep.users.tests.factories import UserFactory
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ..factories import AssessmentFactory, OrganisationFactory
 
 
 class TestListAssessmentsForOrganisation(APITestCase):

--- a/mhep/mhep/v1/tests/views/test_list_assessments_for_organisations.py
+++ b/mhep/mhep/v1/tests/views/test_list_assessments_for_organisations.py
@@ -4,6 +4,8 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 
 from mhep.users.tests.factories import UserFactory
+
+from ... import VERSION
 from ..factories import AssessmentFactory, OrganisationFactory
 
 
@@ -47,7 +49,7 @@ class TestListAssessmentsForOrganisation(APITestCase):
             )
 
         self.client.force_authenticate(self.org_member)
-        response = self.client.get(f"/v1/api/organisations/{self.organisation.pk}/assessments/")
+        response = self.client.get(f"/{VERSION}/api/organisations/{self.organisation.pk}/assessments/")
 
         expected_result = {
             "id": "{}".format(assessment.pk),
@@ -66,7 +68,7 @@ class TestListAssessmentsForOrganisation(APITestCase):
 
     def test_returns_404_for_bad_organisation_id(self):
         self.client.force_authenticate(self.org_member)
-        response = self.client.get("/v1/api/organisations/2/assessments/")
+        response = self.client.get(f"/{VERSION}/api/organisations/2/assessments/")
 
         assert status.HTTP_404_NOT_FOUND == response.status_code
         assert {"detail": "Organisation not found"} == response.json()
@@ -83,7 +85,7 @@ class TestListAssessmentsForOrganisation(APITestCase):
 
     def test_returns_forbidden_if_not_logged_in(self):
         AssessmentFactory.create(organisation=self.organisation)
-        response = self.client.get(f"/v1/api/organisations/{self.organisation.pk}/assessments/")
+        response = self.client.get(f"/{VERSION}/api/organisations/{self.organisation.pk}/assessments/")
 
         assert status.HTTP_403_FORBIDDEN == response.status_code
         assert {"detail": "Authentication credentials were not provided."} == response.json()
@@ -92,14 +94,14 @@ class TestListAssessmentsForOrganisation(APITestCase):
         someone_else = UserFactory.create()
         self.client.force_authenticate(someone_else)
 
-        response = self.client.get(f"/v1/api/organisations/{self.organisation.pk}/assessments/")
+        response = self.client.get(f"/{VERSION}/api/organisations/{self.organisation.pk}/assessments/")
 
         assert status.HTTP_403_FORBIDDEN == response.status_code
         assert {"detail": "You are not a member of the Organisation."} == response.json()
 
     def call_and_assert_number_of_returns_assessments(self, expectedAssessmentCount):
         self.client.force_authenticate(self.org_member)
-        response = self.client.get(f"/v1/api/organisations/{self.organisation.pk}/assessments/")
+        response = self.client.get(f"/{VERSION}/api/organisations/{self.organisation.pk}/assessments/")
 
         assert response.status_code == status.HTTP_200_OK
         assert expectedAssessmentCount == len(response.data)

--- a/mhep/mhep/v1/tests/views/test_list_create_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_list_create_assessments.py
@@ -5,9 +5,12 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
+from ... import VERSION
 from ...models import Assessment
 from ..factories import AssessmentFactory, OrganisationFactory
+
 from mhep.users.tests.factories import UserFactory
+
 User = get_user_model()
 
 
@@ -25,7 +28,7 @@ class TestListAssessments(APITestCase):
                     owner=user,
             )
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
 
         expected_structure = [{
             "id": "{}".format(a1.pk),
@@ -54,7 +57,7 @@ class TestListAssessments(APITestCase):
 
         AssessmentFactory.create(organisation=organisation)
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_200_OK
 
         assert 2 == len(response.data)
@@ -68,13 +71,13 @@ class TestListAssessments(APITestCase):
         AssessmentFactory.create(owner=me)
         AssessmentFactory.create(owner=someone_else)
 
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_200_OK
 
         assert 2 == len(response.data)
 
     def test_returns_forbidden_if_not_logged_in(self):
-        response = self.client.get("/v1/api/assessments/")
+        response = self.client.get(f"/{VERSION}/api/assessments/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -100,7 +103,11 @@ class TestCreateAssessment(APITestCase):
         }
 
         with freeze_time("2019-06-01T16:35:34Z"):
-            response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+            response = self.client.post(
+                    f"/{VERSION}/api/assessments/",
+                    new_assessment,
+                    format="json"
+            )
 
         assert response.status_code == status.HTTP_201_CREATED
 
@@ -130,7 +137,7 @@ class TestCreateAssessment(APITestCase):
             "description": "test description 1",
         }
 
-        response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+        response = self.client.post(f"/{VERSION}/api/assessments/", new_assessment, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         created_assessment = Assessment.objects.get(pk=response.data["id"])
@@ -145,7 +152,7 @@ class TestCreateAssessment(APITestCase):
             "description": "test description 1",
         }
 
-        response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+        response = self.client.post(f"/{VERSION}/api/assessments/", new_assessment, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         created_assessment = Assessment.objects.get(pk=response.data["id"])
@@ -160,7 +167,7 @@ class TestCreateAssessment(APITestCase):
             "data": {"foo": "baz"},
         }
 
-        response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+        response = self.client.post(f"/{VERSION}/api/assessments/", new_assessment, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
         assert "" == response.data["description"]
@@ -171,7 +178,7 @@ class TestCreateAssessment(APITestCase):
                 "openbem_version": "10.1.1",
             }
 
-        response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+        response = self.client.post(f"/{VERSION}/api/assessments/", new_assessment, format="json")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_create_assessment_fails_if_name_missing(self):
@@ -248,6 +255,6 @@ class TestCreateAssessment(APITestCase):
     def assert_create_fails(self, new_assessment, expected_status, expected_response):
         self.client.force_authenticate(self.user)
 
-        response = self.client.post("/v1/api/assessments/", new_assessment, format="json")
+        response = self.client.post(f"/{VERSION}/api/assessments/", new_assessment, format="json")
         assert response.status_code == expected_status
         assert response.data == expected_response

--- a/mhep/mhep/v1/tests/views/test_list_create_assessments.py
+++ b/mhep/mhep/v1/tests/views/test_list_create_assessments.py
@@ -5,8 +5,8 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
-from mhep.v1.models import Assessment
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ...models import Assessment
+from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 User = get_user_model()
 

--- a/mhep/mhep/v1/tests/views/test_list_create_libraries.py
+++ b/mhep/mhep/v1/tests/views/test_list_create_libraries.py
@@ -3,8 +3,10 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
+from ... import VERSION
 from ...models import Library
 from ..factories import LibraryFactory
+
 from mhep.users.tests.factories import UserFactory
 
 
@@ -21,7 +23,7 @@ class TestListCreateLibraries(APITestCase):
             LibraryFactory.create(owner=UserFactory.create())  # another library (someone else's)
 
         self.client.force_authenticate(self.me)
-        response = self.client.get("/v1/api/libraries/")
+        response = self.client.get(f"/{VERSION}/api/libraries/")
         assert response.status_code == status.HTTP_200_OK
 
         assert 2 == len(response.data)
@@ -50,7 +52,7 @@ class TestListCreateLibraries(APITestCase):
         LibraryFactory.create(owner=self.me)
         LibraryFactory.create(owner=self.me)
 
-        response = self.client.get("/v1/api/libraries/")
+        response = self.client.get(f"/{VERSION}/api/libraries/")
         assert status.HTTP_403_FORBIDDEN == response.status_code
 
     def test_create_library(self):
@@ -64,7 +66,7 @@ class TestListCreateLibraries(APITestCase):
 
             self.client.force_authenticate(self.me)
             with freeze_time("2019-06-01T16:35:34Z"):
-                response = self.client.post("/v1/api/libraries/", new_library, format="json")
+                response = self.client.post(f"/{VERSION}/api/libraries/", new_library, format="json")
 
             assert response.status_code == status.HTTP_201_CREATED
 
@@ -91,7 +93,7 @@ class TestListCreateLibraries(APITestCase):
             self.client.force_authenticate(self.me)
 
             with freeze_time("2019-06-01T16:35:34Z"):
-                response = self.client.post("/v1/api/libraries/", new_library, format="json")
+                response = self.client.post(f"/{VERSION}/api/libraries/", new_library, format="json")
 
             assert status.HTTP_400_BAD_REQUEST == response.status_code
             assert {
@@ -110,7 +112,7 @@ class TestListCreateLibraries(APITestCase):
         self.client.force_authenticate(self.me)
 
         with freeze_time("2019-06-01T16:35:34Z"):
-            response = self.client.post("/v1/api/libraries/", new_library, format="json")
+            response = self.client.post(f"/{VERSION}/api/libraries/", new_library, format="json")
 
         assert response.status_code == status.HTTP_201_CREATED
 

--- a/mhep/mhep/v1/tests/views/test_list_create_libraries.py
+++ b/mhep/mhep/v1/tests/views/test_list_create_libraries.py
@@ -3,8 +3,8 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
-from mhep.v1.models import Library
-from mhep.v1.tests.factories import LibraryFactory
+from ...models import Library
+from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_list_organisations.py
+++ b/mhep/mhep/v1/tests/views/test_list_organisations.py
@@ -6,7 +6,9 @@ from collections import OrderedDict
 from rest_framework.test import APITestCase
 from rest_framework import status
 
+from ... import VERSION
 from ..factories import AssessmentFactory, OrganisationFactory
+
 from mhep.users.tests.factories import UserFactory
 
 
@@ -21,7 +23,7 @@ class TestListOrganisations(APITestCase):
         OrganisationFactory.create()  # make another organisation: it shouldn't show up
 
         self.client.force_authenticate(me)
-        response = self.client.get("/v1/api/organisations/")
+        response = self.client.get(f"/{VERSION}/api/organisations/")
         assert response.status_code == status.HTTP_200_OK
 
         expected = [
@@ -42,7 +44,7 @@ class TestListOrganisations(APITestCase):
         assert expected == response.data
 
     def test_returns_forbidden_if_not_logged_in(self):
-        response = self.client.get("/v1/api/organisations/")
+        response = self.client.get(f"/{VERSION}/api/organisations/")
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_if_last_login_is_none_shows_never(self):
@@ -51,7 +53,7 @@ class TestListOrganisations(APITestCase):
         my_org.members.add(me)
 
         self.client.force_authenticate(me)
-        response = self.client.get("/v1/api/organisations/")
+        response = self.client.get(f"/{VERSION}/api/organisations/")
         assert response.status_code == status.HTTP_200_OK
 
         assert "never" == response.data[0]["members"][0]["last_login"]

--- a/mhep/mhep/v1/tests/views/test_list_organisations.py
+++ b/mhep/mhep/v1/tests/views/test_list_organisations.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.tests.factories import AssessmentFactory, OrganisationFactory
+from ..factories import AssessmentFactory, OrganisationFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/v1/tests/views/test_retrieve_update_destroy_assessment.py
@@ -3,8 +3,10 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
+from ... import VERSION
 from ...models import Assessment
 from ..factories import AssessmentFactory
+
 from mhep.users.tests.factories import UserFactory
 
 
@@ -26,7 +28,7 @@ class TestGetAssessment(APITestCase):
             )
 
         self.client.force_authenticate(self.me)
-        response = self.client.get(f"/v1/api/assessments/{a.pk}/")
+        response = self.client.get(f"/{VERSION}/api/assessments/{a.pk}/")
         assert response.status_code == status.HTTP_200_OK
 
         expected = {
@@ -55,7 +57,7 @@ class TestGetAssessment(APITestCase):
             )
 
         self.client.force_authenticate(self.me)
-        response = self.client.get(f"/v1/api/assessments/{a.pk}/")
+        response = self.client.get(f"/{VERSION}/api/assessments/{a.pk}/")
         assert response.status_code == status.HTTP_200_OK
 
         expected = {
@@ -75,7 +77,7 @@ class TestGetAssessment(APITestCase):
         assert expected == response.data
 
     def test_returns_404_for_bad_id(self):
-        response = self.client.get("/v1/api/assessments/bad-id/")
+        response = self.client.get(f"/{VERSION}/api/assessments/bad-id/")
         assert status.HTTP_404_NOT_FOUND == response.status_code
 
 
@@ -104,7 +106,7 @@ class TestUpdateAssessment(APITestCase):
 
             self.client.force_authenticate(self.me)
             response = self.client.patch(
-                f"/v1/api/assessments/{self.assessment.pk}/",
+                f"/{VERSION}/api/assessments/{self.assessment.pk}/",
                 updateFields,
                 format="json",
             )
@@ -126,7 +128,7 @@ class TestUpdateAssessment(APITestCase):
             }
             self.client.force_authenticate(self.me)
             response = self.client.patch(
-                f"/v1/api/assessments/{self.assessment.pk}/",
+                f"/{VERSION}/api/assessments/{self.assessment.pk}/",
                 updateFields,
                 format="json",
             )
@@ -149,7 +151,7 @@ class TestUpdateAssessment(APITestCase):
 
             self.client.force_authenticate(self.me)
             response = self.client.patch(
-                f"/v1/api/assessments/{self.assessment.pk}/",
+                f"/{VERSION}/api/assessments/{self.assessment.pk}/",
                 updateFields,
                 format="json",
             )
@@ -168,7 +170,7 @@ class TestUpdateAssessment(APITestCase):
 
             self.client.force_authenticate(self.me)
             response = self.client.patch(
-                f"/v1/api/assessments/{self.assessment.pk}/",
+                f"/{VERSION}/api/assessments/{self.assessment.pk}/",
                 updateFields,
                 format="json",
             )
@@ -205,7 +207,7 @@ class TestDestroyAssessment(APITestCase):
         assessment_count = Assessment.objects.count()
 
         self.client.force_authenticate(self.me)
-        response = self.client.delete(f"/v1/api/assessments/{a.pk}/")
+        response = self.client.delete(f"/{VERSION}/api/assessments/{a.pk}/")
 
         assert status.HTTP_204_NO_CONTENT == response.status_code
         assert b"" == response.content

--- a/mhep/mhep/v1/tests/views/test_retrieve_update_destroy_assessment.py
+++ b/mhep/mhep/v1/tests/views/test_retrieve_update_destroy_assessment.py
@@ -3,8 +3,8 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import exceptions, status
 
-from mhep.v1.models import Assessment
-from mhep.v1.tests.factories import AssessmentFactory
+from ...models import Assessment
+from ..factories import AssessmentFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_update_destroy_library.py
+++ b/mhep/mhep/v1/tests/views/test_update_destroy_library.py
@@ -3,8 +3,8 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.models import Library
-from mhep.v1.tests.factories import LibraryFactory
+from ...models import Library
+from ..factories import LibraryFactory
 from mhep.users.tests.factories import UserFactory
 
 

--- a/mhep/mhep/v1/tests/views/test_update_destroy_library.py
+++ b/mhep/mhep/v1/tests/views/test_update_destroy_library.py
@@ -3,8 +3,10 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
+from ... import VERSION
 from ...models import Library
 from ..factories import LibraryFactory
+
 from mhep.users.tests.factories import UserFactory
 
 
@@ -31,7 +33,7 @@ class TestUpdateLibrary(APITestCase):
             self.client.force_authenticate(self.me)
 
             response = self.client.patch(
-                "/v1/api/libraries/{}/".format(lib.pk),
+                f"/{VERSION}/api/libraries/{lib.pk}/",
                 updateFields,
                 format="json",
             )
@@ -56,7 +58,7 @@ class TestUpdateLibrary(APITestCase):
 
             self.client.force_authenticate(self.me)
             response = self.client.patch(
-                "/v1/api/libraries/{}/".format(lib.pk),
+                f"/{VERSION}/api/libraries/{lib.pk}/",
                 updateFields,
                 format="json",
             )
@@ -74,7 +76,7 @@ class TestUpdateLibrary(APITestCase):
         assessment_count = Library.objects.count()
 
         self.client.force_authenticate(self.me)
-        response = self.client.delete(f"/v1/api/libraries/{lib.pk}/")
+        response = self.client.delete(f"/{VERSION}/api/libraries/{lib.pk}/")
 
         assert status.HTTP_204_NO_CONTENT == response.status_code
         assert b"" == response.content

--- a/mhep/mhep/v1/tests/views/test_update_destroy_library_item.py
+++ b/mhep/mhep/v1/tests/views/test_update_destroy_library_item.py
@@ -4,8 +4,8 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
-from mhep.v1.models import Library
-from mhep.v1.tests.factories import LibraryFactory
+from ...models import Library
+from ..factories import LibraryFactory
 
 
 class TestUpdateDestroyLibraryItem(APITestCase):

--- a/mhep/mhep/v1/tests/views/test_update_destroy_library_item.py
+++ b/mhep/mhep/v1/tests/views/test_update_destroy_library_item.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 from rest_framework.test import APITestCase
 from rest_framework import status
 
+from ... import VERSION
 from ...models import Library
 from ..factories import LibraryFactory
 
@@ -18,7 +19,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
         )
 
         self.client.force_authenticate(library.owner)
-        response = self.client.delete(f"/v1/api/libraries/{library.id}/items/tag2/")
+        response = self.client.delete(f"/{VERSION}/api/libraries/{library.id}/items/tag2/")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
@@ -40,7 +41,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
         with freeze_time("2019-06-01T16:35:34Z"):
             self.client.force_authenticate(library.owner)
             response = self.client.put(
-                f"/v1/api/libraries/{library.id}/items/tag1/",
+                f"/{VERSION}/api/libraries/{library.id}/items/tag1/",
                 replacement_data,
                 format="json"
             )
@@ -60,7 +61,7 @@ class TestUpdateDestroyLibraryItem(APITestCase):
         self.client.force_authenticate(library.owner)
 
         response = self.client.put(
-            f"/v1/api/libraries/{library.id}/items/tag5/",
+            f"/{VERSION}/api/libraries/{library.id}/items/tag5/",
             replacement_data,
             format="json"
         )

--- a/mhep/mhep/v1/urls.py
+++ b/mhep/mhep/v1/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from django.urls import path
 from django.views.generic import TemplateView
 
-from mhep.v1.views import (
+from .views import (
     AssessmentHTMLView,
     CreateUpdateDeleteLibraryItem,
     ListAssessmentsHTMLView,

--- a/mhep/mhep/v1/views.py
+++ b/mhep/mhep/v1/views.py
@@ -10,14 +10,14 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework import status
 
-from mhep.v1.models import Assessment, Organisation
-from mhep.v1.permissions import (
+from .models import Assessment, Organisation
+from .permissions import (
     IsMemberOfConnectedOrganisation,
     IsMemberOfOrganisation,
     IsAssessmentOwner,
     IsLibraryOwner,
 )
-from mhep.v1.serializers import (
+from .serializers import (
     AssessmentFullSerializer,
     AssessmentMetadataSerializer,
     LibraryItemSerializer,

--- a/mhep/mhep/v1/views.py
+++ b/mhep/mhep/v1/views.py
@@ -54,6 +54,16 @@ class AssessmentHTMLView(AssessmentQuerySetMixin, LoginRequiredMixin, DetailView
         context["locked_javascript"] = json.dumps(locked)
         context["reports_javascript"] = json.dumps([])
         context["use_image_gallery"] = False
+        context["VERSION"] = VERSION
+        return context
+
+
+class ListAssessmentsHTMLView(LoginRequiredMixin, TemplateView):
+    template_name = f"{VERSION}/assessments.html"
+
+    def get_context_data(self, object=None, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["VERSION"] = VERSION
         return context
 
 
@@ -228,7 +238,3 @@ class ListCreateOrganisationAssessments(generics.ListCreateAPIView):
             )
         except Organisation.DoesNotExist:
             raise exceptions.NotFound("Organisation not found")
-
-
-class ListAssessmentsHTMLView(LoginRequiredMixin, TemplateView):
-    template_name = f"{VERSION}/assessments.html"

--- a/mhep/mhep/v1/views.py
+++ b/mhep/mhep/v1/views.py
@@ -25,6 +25,8 @@ from .serializers import (
     OrganisationSerializer,
 )
 
+from . import VERSION
+
 
 class AssessmentQuerySetMixin():
     def get_queryset(self, *args, **kwargs):
@@ -40,7 +42,7 @@ class BadRequest(exceptions.APIException):
 
 
 class AssessmentHTMLView(AssessmentQuerySetMixin, LoginRequiredMixin, DetailView):
-    template_name = "v1/view.html"
+    template_name = f"{VERSION}/view.html"
     context_object_name = "assessment"
     model = Assessment
 
@@ -229,4 +231,4 @@ class ListCreateOrganisationAssessments(generics.ListCreateAPIView):
 
 
 class ListAssessmentsHTMLView(LoginRequiredMixin, TemplateView):
-    template_name = "v1/assessments.html"
+    template_name = f"{VERSION}/assessments.html"


### PR DESCRIPTION
* set VERSION from app's directory name e.g. `v1` - so when the code is copied to `v2` VERSION will be set automatically
* AppConfig: set name|verbose_name using VERSION
* remove v1 from import statements: `from mhep.v1.? import` -> `from .? import`
* remove hardcoded `v1` from {% url .. %}
* remove hardcoded `v1` from {% include .. %}
* remove hardcoded `v1` from {% extends .. %}
* remove hardcoded `v1` from {% static .. %}
* urlHelper functions: use VERSION not `v1:`
* add urlHelper.admin.organisation(orgid)
* urlHelper.static: prepend `v1/` from VERSION so you just use it like `urlHelper.static('img/blah')` and it fetches
  `<static url>/v1/img/blah`
* view tests: use VERSION over "v1"
* test_urls: replace `v1` with "{VERSION}"
* views: set template_name using VERSION