### PR TITLE
fix whitenoise: pre-generate a lookup of static files

### DIFF
--- a/mhep/mhep/v1/helpers.py
+++ b/mhep/mhep/v1/helpers.py
@@ -1,0 +1,44 @@
+import os
+
+from os.path import abspath, dirname, join
+
+from django.contrib.staticfiles.templatetags.staticfiles import static
+
+from . import VERSION
+
+
+def build_static_dictionary():
+    """
+    calls find_app_static_files() and returns a dictionary for example:
+    {
+        "js/foo.js": "/static/v1/js/foo.js"
+    }
+
+    or even like:
+    {
+        "js/foo.js": "https://some-cdn.com/static/v1/js/foo.js"
+    }
+
+    note that the dictionary value is created by calling the `static` helper, so depends
+    on the specific static backend.
+    """
+    return {fn: static(os.path.join(VERSION, fn)) for fn in find_app_static_files()}
+
+
+def find_app_static_files():
+    """
+    traverses the directory tree inside {app}/static/{VERSION}, yielding filenames like
+    "js/example.js"  (not "v1/js/example.js")
+    "css/foo.css",
+
+    note that the version static subdirectory is stripped
+    """
+
+    static_dir = join(abspath(dirname(__file__)), "static", VERSION)
+
+    for root, dirs, files in os.walk(static_dir):
+        for fn in files:
+            full_filename = join(root, fn)
+            relative_filename = full_filename[len(static_dir)+1:]
+            # print("relative: {}".format(relative_filename))
+            yield relative_filename

--- a/mhep/mhep/v1/templates/v1/js/url_helper.js
+++ b/mhep/mhep/v1/templates/v1/js/url_helper.js
@@ -54,8 +54,12 @@
 
       static: function (resourcePath) {
         // returns the full URL for the given static file e.g. 'img/graphic.png'
-        const dummyURL = '{% static VERSION|add:"/12345" %}';
-        return dummyURL.replace(/12345/, resourcePath);
+        const appStaticURLs = {{ static_urls |safe }};
+        if (!appStaticURLs.hasOwnProperty(resourcePath)) {
+          console.error("no app static URL for '" + resourcePath + "'");
+        }
+
+        return appStaticURLs[resourcePath];
       },
 
       admin: {

--- a/mhep/mhep/v1/views.py
+++ b/mhep/mhep/v1/views.py
@@ -41,7 +41,14 @@ class BadRequest(exceptions.APIException):
     status_code = status.HTTP_400_BAD_REQUEST
 
 
-class AssessmentHTMLView(AssessmentQuerySetMixin, LoginRequiredMixin, DetailView):
+class CommonContextMixin():
+    def get_context_data(self, object=None, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["VERSION"] = VERSION
+        return context
+
+
+class AssessmentHTMLView(CommonContextMixin, AssessmentQuerySetMixin, LoginRequiredMixin, DetailView):
     template_name = f"{VERSION}/view.html"
     context_object_name = "assessment"
     model = Assessment
@@ -54,17 +61,12 @@ class AssessmentHTMLView(AssessmentQuerySetMixin, LoginRequiredMixin, DetailView
         context["locked_javascript"] = json.dumps(locked)
         context["reports_javascript"] = json.dumps([])
         context["use_image_gallery"] = False
-        context["VERSION"] = VERSION
         return context
 
 
-class ListAssessmentsHTMLView(LoginRequiredMixin, TemplateView):
+class ListAssessmentsHTMLView(CommonContextMixin, LoginRequiredMixin, TemplateView):
     template_name = f"{VERSION}/assessments.html"
 
-    def get_context_data(self, object=None, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["VERSION"] = VERSION
-        return context
 
 
 class ListCreateAssessments(

--- a/mhep/mhep/v1/views.py
+++ b/mhep/mhep/v1/views.py
@@ -26,6 +26,9 @@ from .serializers import (
 )
 
 from . import VERSION
+from .helpers import build_static_dictionary
+
+STATIC_URLS = build_static_dictionary()
 
 
 class AssessmentQuerySetMixin():
@@ -45,6 +48,7 @@ class CommonContextMixin():
     def get_context_data(self, object=None, **kwargs):
         context = super().get_context_data(**kwargs)
         context["VERSION"] = VERSION
+        context["static_urls"] = json.dumps(STATIC_URLS, indent=4)
         return context
 
 


### PR DESCRIPTION
inspired by idea 2) in
https://gist.github.com/takkaria/b3dc8ee8c3c65e39243afe57db4a77ee#2-have-our-own-manifest

we took this approach with two modifications:

1) rather than using an arbitrary key like `"PAGE_CONTEXT_HTML"`, just
 use the partial path of `resourceURL` e.g. `subviews/context.html`. So
 JS code can simply do `urlHelpers.static('subview/context.html')`

2) pre-calculate all the resulting static urls in Django (once) rather
  than inside the template. we use the `static` function which is
  equivalent to the `{% static ... %}` template tag