### PR TITLE
delete user_with_org test fixture

### DIFF
--- a/mhep/mhep/conftest.py
+++ b/mhep/mhep/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.conf import settings
 from django.test import RequestFactory
 
-from mhep.users.tests.factories import UserFactory, UserWithOrganisationFactory
+from mhep.users.tests.factories import UserFactory
 
 
 @pytest.fixture(autouse=True)
@@ -13,11 +13,6 @@ def media_storage(settings, tmpdir):
 @pytest.fixture
 def user() -> settings.AUTH_USER_MODEL:
     return UserFactory()
-
-
-@pytest.fixture
-def user_with_org() -> settings.AUTH_USER_MODEL:
-    return UserWithOrganisationFactory()
 
 
 @pytest.fixture

--- a/mhep/mhep/users/tests/factories.py
+++ b/mhep/mhep/users/tests/factories.py
@@ -2,7 +2,6 @@ from typing import Any, Sequence
 
 from django.contrib.auth import get_user_model
 from factory import DjangoModelFactory, Faker, post_generation
-from mhep.v1.models import Organisation
 
 
 class UserFactory(DjangoModelFactory):
@@ -26,10 +25,3 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = get_user_model()
         django_get_or_create = ["username"]
-
-
-class UserWithOrganisationFactory(UserFactory):
-    @post_generation
-    def organisations(self, create: bool, extracted: Sequence[Any], **kwargs):
-        org = Organisation.objects.create(name='fake organisation')
-        self.v1_organisations.add(org)

--- a/mhep/mhep/v1/tests/test_models.py
+++ b/mhep/mhep/v1/tests/test_models.py
@@ -1,9 +1,9 @@
 import pytest
 
-from django.conf import settings
 
 from .. import VERSION
 from ..models import Organisation
+from ..tests.factories import UserFactory, OrganisationFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -12,5 +12,12 @@ def test_organisation_assessments(organisation_with_extras: Organisation):
     assert organisation_with_extras.assessments.all().count() == 1
 
 
-def test_organisations_related_name_on_user_model(user_with_org: settings.AUTH_USER_MODEL):
-    assert getattr(user_with_org, f"{VERSION}_organisations").all().count() == 1
+def test_organisations_related_name_on_user_model():
+    user = UserFactory.create()
+    org = OrganisationFactory.create()
+
+    org.members.add(user)
+    # Organisation.members is the forward relationship
+    # and User.{version}_organisations is the reverse
+
+    assert getattr(user, f"{VERSION}_organisations").all().count() == 1


### PR DESCRIPTION
I found this bug when freezing `v1` and starting the `dev` version.

`user_with_org` test fixture is coupled to a specific app version's Organisation model. We don't need it, so do the test another way.