### PR TITLE
Improve UI for editing elements in libraries

### DIFF
--- a/mhep/mhep/v1/static/v1/css/emon-blue.css
+++ b/mhep/mhep/v1/static/v1/css/emon-blue.css
@@ -132,3 +132,7 @@ input[type=text][class=variable-name-edit] {
 .caret {
    border-top-color: #fff !important;
 }
+
+tr.item {
+    vertical-align: top;
+}

--- a/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
+++ b/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
@@ -914,6 +914,9 @@ libraryHelper.prototype.onSaveLibraryEditMode = function (selector, library_id) 
                 else if ($(this).children('select')[0] != undefined) {
                     data[tag][key] = $(this).children('select')[0].value;
                 }
+                else if ($(this).children('textarea')[0] != undefined) {
+                    data[tag][key] = $(this).children('textarea')[0].value;
+                }
                 else
                     console.error("Type of input not recognized: ");
                 /*if(element.type)
@@ -1250,17 +1253,17 @@ libraryHelper.prototype.generation_measures_library_to_html = function (origin, 
  * Libraries to html - Edit mode (for lilbraries manager)
  **********************************************/
 libraryHelper.prototype.measure_fields_for_library_to_html_edit_mode = function (item) {
-    var out = '<td index="description" title="' + item.description + '"><input type="text" value="' + item.description + '" /></td>';
-    out += '<td index="performance" title="' + item.performance + '"><input class="w100" type="text" value="' + item.performance + '" /></td>';
-    out += '<td index="benefits" class="" title="' + item.benefits + '"><input type="text" value="' + item.benefits + '" /></td>';
+    var out = '<td index="description" title="' + item.description + '"><textarea rows="8" style="width: 400px;">' + item.description + '</textarea></td>';
+    out += '<td index="performance" title="' + item.performance + '"><textarea rows="3">' + item.performance + '</textarea></td>';
+    out += '<td index="benefits" class="" title="' + item.benefits + '"><textarea rows="3">' + item.benefits + '</textarea></td>';
     out += '<td index="cost"><input class="w50" type="text" value="' + item.cost + '" /></td>';
     out += '<td index="cost_units">' + this.get_cost_units_select(item) + '</td>';
     out += '<td index="who_by" class="" title="' + item.who_by + '"><input type="text" value="' + item.who_by + '" /></td>';
     out += '<td index="disruption" title="' + item.disruption + '"><input class="w100" type="text" value="' + item.disruption + '" /></td>';
-    out += '<td index="associated_work" class="" title="' + item.associated_work + '"><input type="text" value="' + item.associated_work + '" /></td>';
-    out += '<td index="key_risks" class="" title="' + item.key_risks + '"><input type="text" value="' + item.key_risks + '" /></td>';
-    out += '<td index="notes" class="" title="' + item.notes + '"><input type="text" value="' + item.notes + '" /></td>';
-    out += '<td index="maintenance" title="' + item.maintenance + '"><input class="w100" type="text" value="' + item.maintenance + '" /></td>';
+    out += '<td index="associated_work" class="" title="' + item.associated_work + '"><textarea rows="5">' + item.associated_work + '</textarea></td>';
+    out += '<td index="key_risks" class="" title="' + item.key_risks + '"><textarea rows="5">' + item.key_risks + '</textarea></td>';
+    out += '<td index="notes" class="" title="' + item.notes + '"><textarea rows="8" style="width: 400px;">' + item.notes + '</textarea></td>';
+    out += '<td index="maintenance" title="' + item.maintenance + '"><textarea rows="8" style="width: 400px;">' + item.maintenance + '</textarea></td>';
     return out;
 };
 libraryHelper.prototype.elements_library_to_html_edit_mode = function (origin, library_id) {

--- a/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
+++ b/mhep/mhep/v1/static/v1/js/library-helper/library-helper.js
@@ -1311,7 +1311,7 @@ libraryHelper.prototype.elements_library_to_html_edit_mode = function (origin, l
                         out += '<td index="gL"><input class="w50" type="number" min="0" step="0.01" value="' + item.gL + '" /></td>';
                         out += '<td index="ff"><input class="w50" type="number" min="0" step="0.01" value="' + item.ff + '" /></td>';
                     }
-                    out += '<td index="description" title="' + item.description + '"><input clas="w300" type="text" value="' + item.description + '" /></td>';
+                    out += '<td index="description" title="' + item.description + '"><textarea rows="8" class="w350">' + item.description + '"</textarea></td>';
                     out += '<td><i class="icon-trash if-write delete-library-item" tag="' + z + '" library="' + library_id + '" style="cursor:pointer;margin-left:10px;margin-right:20px"></i></td>';
                     out += '</tr>';
                 }


### PR DESCRIPTION
Some of the library item fields were difficult to edit as the content was truncated in `input` fields. This change changes those containing larger amounts of text into `textarea` tags.

![Screenshot 2019-11-14 at 15 24 48](https://user-images.githubusercontent.com/55195/68870509-eb6f1780-06f2-11ea-855d-8b8ad9e92717.png)
