### PR TITLE
simplify library <> organisation relationship

### DIFF
--- a/mhep/mhep/dev/models/library.py
+++ b/mhep/mhep/dev/models/library.py
@@ -19,7 +19,7 @@ class Library(models.Model):
         Organisation,
         null=True, blank=True,
         on_delete=models.PROTECT,
-        related_name="%(app_label)s_libraries",
+        related_name="libraries",
     )
 
     name = models.TextField()

--- a/mhep/mhep/dev/tests/test_models.py
+++ b/mhep/mhep/dev/tests/test_models.py
@@ -5,7 +5,7 @@ from django.db.utils import IntegrityError
 
 from .. import VERSION
 from ..models import Library, Organisation
-from ..tests.factories import UserFactory, OrganisationFactory
+from ..tests.factories import LibraryFactory, UserFactory, OrganisationFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -19,10 +19,32 @@ def test_organisations_related_name_on_user_model():
     org = OrganisationFactory.create()
 
     org.members.add(user)
-    # Organisation.members is the forward relationship
-    # and User.{version}_organisations is the reverse
+    # `Organisation.members` is the forward relationship
+    # `User.{version}_organisations` is the reverse
 
     assert getattr(user, f"{VERSION}_organisations").all().count() == 1
+
+
+def test_libraries_related_name_on_user_model():
+    user = UserFactory.create()
+
+    LibraryFactory.create(owner_user=user, owner_organisation=None)
+
+    # `Library.owner_user` is the forward relationship
+    # `User.{version}_libraries` is the reverse
+
+    assert getattr(user, f"{VERSION}_libraries").all().count() == 1
+
+
+def test_libraries_related_name_on_organisation_model():
+    org = OrganisationFactory.create()
+
+    LibraryFactory.create(owner_organisation=org, owner_user=None)
+
+    # `Library.owner_organisation` is the forward relationship
+    # `Organisation.libraries` is the reverse
+
+    assert org.libraries.all().count() == 1
 
 
 class TestOrganisationOwner():


### PR DESCRIPTION
the forward relationship is `Library.owner_organisation` and the reverse
is `Organisation.libraries` - not that this doesn't need a version in
the related name.