### PR TITLE
fix warnings during tests (RemovedInDjango30Warning)

### DIFF
--- a/mhep/mhep/dev/views/helpers.py
+++ b/mhep/mhep/dev/views/helpers.py
@@ -2,7 +2,7 @@ import os
 
 from os.path import abspath, dirname, join
 
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 from .. import VERSION
 

--- a/mhep/mhep/v1/helpers.py
+++ b/mhep/mhep/v1/helpers.py
@@ -2,7 +2,7 @@ import os
 
 from os.path import abspath, dirname, join
 
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 from . import VERSION
 


### PR DESCRIPTION
django.contrib.staticfiles.templatetags.static() is deprecated in favor of
django.templatetags.static.static

note: this is a bit naughty since we're backporting to `v1` - but since
it's such early days I think it's acceptable at this point :)