### PR TITLE
Add eslintrc

### DIFF
--- a/mhep/.eslintrc.json
+++ b/mhep/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 2018,
+        "sourceType": "script"
+    },
+    "rules": {
+        "linebreak-style": ["error", "unix"],
+        "quotes": ["error", "double", "avoid-escape"],
+        "semi": ["error", "always"],
+        "no-console": "off",
+        "indent": "off",
+        "curly": ["error", "all"],
+        "brace-style": ["error", "1tbs"],
+        "indent": ["error", 4, { "SwitchCase": 1 }]
+    }
+}


### PR DESCRIPTION
Not hooked into anything at present but I'm using it locally so I thought it should be here too.

At some point I'd like to run eslint over the whole JS codebase so it's consistently formatted, but I don't want to do it while there are significant works in progress!