### PR TITLE
return permissions for organisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ HTTP 204 No content
 GET /organisations/
 ```
 
-List all organisations the current user is a member of.
+List all organisations the current user is a member of. Each organisation also returns `permissions`, which shows what the current user can and can not do.
 
 ℹ️ porting notes: replaces previous `assessment/getorganisations` route.
 
@@ -430,7 +430,11 @@ Content-Type: application/json
                 "is_admin": True,
                 "is_librarian": True
             }
-        ]
+        ],
+        "permissions": {
+            "can_add_remove_members": True,
+            "can_promote_demote_librarians": True,
+        }
     },
     {
         "id": "2",
@@ -451,7 +455,11 @@ Content-Type: application/json
                 "is_admin": False,
                 "is_librarian": True
             }
-        ]
+        ],
+        "permissions": {
+            "can_add_remove_members": True,
+            "can_promote_demote_librarians": True,
+        }
     }
 ]
 ```

--- a/mhep/mhep/dev/serializers.py
+++ b/mhep/mhep/dev/serializers.py
@@ -180,6 +180,7 @@ class LibraryItemSerializer(serializers.Serializer):
 
 class OrganisationSerializer(StringIDMixin, serializers.ModelSerializer):
     id = serializers.SerializerMethodField()
+    permissions = serializers.SerializerMethodField()
     assessments = serializers.SerializerMethodField()
     members = serializers.SerializerMethodField()
 
@@ -190,6 +191,7 @@ class OrganisationSerializer(StringIDMixin, serializers.ModelSerializer):
             "name",
             "assessments",
             "members",
+            "permissions",
         ]
 
     def get_assessments(self, obj):
@@ -206,6 +208,12 @@ class OrganisationSerializer(StringIDMixin, serializers.ModelSerializer):
             }
 
         return [userinfo(u) for u in org.members.all()]
+
+    def get_permissions(self, org):
+        user = self.context['request'].user
+        return {
+            "can_add_remove_members": user in org.admins.all(),
+        }
 
 
 class OrganisationLibrarianSerializer(serializers.ModelSerializer):

--- a/mhep/mhep/dev/serializers.py
+++ b/mhep/mhep/dev/serializers.py
@@ -213,6 +213,7 @@ class OrganisationSerializer(StringIDMixin, serializers.ModelSerializer):
         user = self.context['request'].user
         return {
             "can_add_remove_members": user in org.admins.all(),
+            "can_promote_demote_librarians": user in org.admins.all(),
         }
 
 

--- a/mhep/mhep/dev/tests/views/test_organisations.py
+++ b/mhep/mhep/dev/tests/views/test_organisations.py
@@ -57,6 +57,7 @@ class TestListOrganisations(APITestCase):
                 ]),
                 ("permissions", {
                     "can_add_remove_members": False,
+                    "can_promote_demote_librarians": False,
                 }),
             ]),
         ]
@@ -104,6 +105,7 @@ class TestListOrganisationsPermissions(APITestCase):
             self.client.get(f"/{VERSION}/api/organisations/"),
             {
                 "can_add_remove_members": False,
+                "can_promote_demote_librarians": False,
             }
         )
 
@@ -114,6 +116,7 @@ class TestListOrganisationsPermissions(APITestCase):
             self.client.get(f"/{VERSION}/api/organisations/"),
             {
                 "can_add_remove_members": True,
+                "can_promote_demote_librarians": True,
             }
         )
 


### PR DESCRIPTION
We'll use this to alter what buttons and forms are presented to the user in the organisation view.