### PR TITLE
fix verbose assertions from AssertErrorMixin

### DIFF
--- a/mhep/mhep/dev/conftest.py
+++ b/mhep/mhep/dev/conftest.py
@@ -8,6 +8,10 @@ from mhep.v1.tests.factories import (
 )
 from mhep.v1.models import Assessment, Library, Organisation
 
+from . import VERSION
+
+pytest.register_assert_rewrite(f"mhep.{VERSION}.tests.views.mixins.assert_error")
+
 
 @pytest.fixture
 def assessment() -> Assessment:


### PR DESCRIPTION
back in 9c483376e4a562bbf0102a7b562695476fbd4699 I factored out
AssertErrorMixin, allowing tests to call `self._assert_error(..)`

Unfortunately this broke pytest's nice verbose assertion messages so
they look like this:

```
    def _assert_error(self, response, expected_status, expected_detail):
>       assert expected_status == response.status_code
E       AssertionError
```

this change means pytest knows to include AssertErrorMixin when it's
rewriting assertion code, so it looks like this again:

```
    def _assert_error(self, response, expected_status, expected_detail):
>       assert expected_status == response.status_code
E       AssertionError: assert 403 == 200
E        +  where 200 = <Response status_code=200,
"application/json">.status_code

mhep/dev/tests/views/mixins/assert_error.py:3: AssertionError
```